### PR TITLE
Adding timing-aware methods and classes

### DIFF
--- a/forecaster/__init__.py
+++ b/forecaster/__init__.py
@@ -24,3 +24,4 @@ from forecaster.forecast import (
     ContributionForecast, ReductionForecast, WithdrawalForecast,
     TaxForecast)
 from forecaster.forecaster import Forecaster, Parameter
+from forecaster.utility import Timing

--- a/forecaster/accounts/base.py
+++ b/forecaster/accounts/base.py
@@ -519,7 +519,7 @@ class Account(TaxSource):
         return transactions
 
     def max_outflows(
-            self, timing=None, balance_limit=None, outflow_limit=None):
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The maximum amounts that can be withdrawn at `timings`.
 
         The output transaction values will be proportionate to the
@@ -537,8 +537,8 @@ class Account(TaxSource):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): At least this balance, if provided,
                 will remain in the account at year-end. Optional.
-            outflow_limit (Money): Total outflows will not exceed this
-                amount (not including any outflows already recorded
+            transaction_limit (Money): Total outflows will not exceed
+                this amount (not including any outflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -550,10 +550,10 @@ class Account(TaxSource):
         if balance_limit is None:
             # Outflows are limited by the account balance:
             balance_limit = Money(0)
-        if outflow_limit is None:
+        if transaction_limit is None:
             # Limit to max total outflows, accounting for any existing
             # inflows already recorded as transactions:
-            outflow_limit = min(
+            transaction_limit = min(
                 self.max_outflow - self.outflows,
                 # Don't allow positive lower bounds:
                 Money(0))
@@ -563,10 +563,10 @@ class Account(TaxSource):
             balance_limit,
             timing=timing,
             max_total=max_total,
-            min_total=outflow_limit)
+            min_total=transaction_limit)
 
     def max_inflows(
-            self, timing=None, balance_limit=None, inflow_limit=None):
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The maximum amounts that can be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -580,8 +580,8 @@ class Account(TaxSource):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): This balance, if provided, will not
                 be exceeded at year-end. Optional.
-            inflow_limit (Money): Total inflows will not exceed this
-                amount (not including any inflows already recorded
+            transaction_limit (Money): Total inflows will not exceed
+                this amount (not including any inflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -594,8 +594,8 @@ class Account(TaxSource):
             balance_limit = Money('Infinity')
         # Limit to max total inflows, accounting for any existing
         # inflows already recorded as transactions:
-        if inflow_limit is None:
-            inflow_limit = max(
+        if transaction_limit is None:
+            transaction_limit = max(
                 self.max_inflow - self.inflows,
                 # Don't allow negative upper bound:
                 Money(0))
@@ -604,11 +604,11 @@ class Account(TaxSource):
         return self.transactions_to_balance(
             balance_limit,
             timing=timing,
-            max_total=inflow_limit,
+            max_total=transaction_limit,
             min_total=min_total)
 
     def min_outflows(
-            self, timing=None, balance_limit=None, outflow_limit=None):
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The minimum outflows that should be withdrawn at `timings`.
 
         The output transaction values will be proportionate to the
@@ -622,8 +622,8 @@ class Account(TaxSource):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): At least this balance, if provided,
                 will remain in the account at year-end. Optional.
-            outflow_limit (Money): Total outflows will not exceed this
-                amount (not including any outflows already recorded
+            transaction_limit (Money): Total outflows will not exceed
+                this amount (not including any outflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -634,9 +634,9 @@ class Account(TaxSource):
         if balance_limit is None:
             # Outflows are limited by the account balance:
             balance_limit = Money(0)
-        if outflow_limit is None:
+        if transaction_limit is None:
             # Ensure that the largest possible outflow is non-positive:
-            outflow_limit = min(
+            transaction_limit = min(
                 self.min_outflow - self.outflows,
                 # Don't allow positive lower bounds:
                 Money(0))
@@ -646,10 +646,10 @@ class Account(TaxSource):
             balance_limit,
             timing=timing,
             max_total=max_total,
-            min_total=outflow_limit)
+            min_total=transaction_limit)
 
     def min_inflows(
-            self, timing=None, balance_limit=None, inflow_limit=None):
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The minimum amounts that should be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -663,8 +663,8 @@ class Account(TaxSource):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): This balance, if provided, will not
                 be exceeded at year-end. Optional.
-            inflow_limit (Money): Total inflows will not exceed this
-                amount (not including any inflows already recorded
+            transaction_limit (Money): Total inflows will not exceed
+                this amount (not including any inflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -677,8 +677,8 @@ class Account(TaxSource):
             balance_limit = Money('Infinity')
         # Limit to min. total inflows, accounting for any existing
         # inflows already recorded as transactions:
-        if inflow_limit is None:
-            inflow_limit = max(
+        if transaction_limit is None:
+            transaction_limit = max(
                 self.min_inflow - self.inflows,
                 # Don't allow negative upper bound:
                 Money(0))
@@ -687,7 +687,7 @@ class Account(TaxSource):
         return self.transactions_to_balance(
             balance_limit,
             timing=timing,
-            max_total=inflow_limit,
+            max_total=transaction_limit,
             min_total=min_total)
 
     @recorded_property

--- a/forecaster/accounts/contribution_limited.py
+++ b/forecaster/accounts/contribution_limited.py
@@ -151,6 +151,7 @@ class ContributionLimitAccount(Account):
             'RegisteredAccount: next_contribution_room is not implemented. '
             + 'Subclasses must override this method.')
 
-    def max_inflow(self, when='end'):
-        """ Limits outflows based on available contribution room. """
-        return self.contribution_room_history[self.this_year]
+    @property
+    def max_inflow(self):
+        """ Limits outflows based on contribution room for the year. """
+        return self.contribution_room

--- a/forecaster/accounts/contribution_limited.py
+++ b/forecaster/accounts/contribution_limited.py
@@ -152,6 +152,6 @@ class ContributionLimitAccount(Account):
             + 'Subclasses must override this method.')
 
     @property
-    def max_inflow(self):
+    def max_inflow_limit(self):
         """ Limits outflows based on contribution room for the year. """
         return self.contribution_room

--- a/forecaster/accounts/debt.py
+++ b/forecaster/accounts/debt.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 from forecaster.accounts.base import Account
 from forecaster.ledger import Money
-from forecaster.utility import frequency_conv
+from forecaster.utility import frequency_conv, when_conv
 
 class Debt(Account):
     """ A debt with a balance and an interest rate.
@@ -37,6 +37,10 @@ class Debt(Account):
             `forecaster.utility.frequency_conv` (e.g. 'M' or 12
             for monthly payments).
             Optional; defaults to monthly payments.
+        payment_timing (str, int): When payments are made in each
+            payment period (e.g. 'start', 'end', 0.5). Uses the same
+            syntax as `forecaster.utility.when_conv`.
+            Optional; defaults to 'end'.
     """
 
     def __init__(
@@ -45,7 +49,7 @@ class Debt(Account):
             inputs=None, initial_year=None, minimum_payment=Money(0),
             living_expense=Money(0), savings_rate=1,
             accelerated_payment=Money('Infinity'),
-            payment_frequency='M',
+            payment_frequency='M', payment_timing='end',
             **kwargs):
         """ Constructor for `Debt`. """
 
@@ -61,6 +65,7 @@ class Debt(Account):
         self._savings_rate = None
         self._accelerated_payment = None
         self._payment_frequency = None
+        self._payment_timing = None
 
         # Apply generic Account logic:
         super().__init__(
@@ -73,6 +78,7 @@ class Debt(Account):
         self.savings_rate = savings_rate
         self.accelerated_payment = accelerated_payment
         self.payment_frequency = payment_frequency
+        self.payment_timing = payment_timing
 
         # Debt must have a negative balance
         if self.balance > 0:
@@ -127,6 +133,16 @@ class Debt(Account):
     def payment_frequency(self, val):
         """ Sets the debt's payment frequency. """
         self._payment_frequency = frequency_conv(val)
+
+    @property
+    def payment_timing(self):
+        """ When the debt's payments are due in each payment period. """
+        return self._payment_timing
+
+    @payment_timing.setter
+    def payment_timing(self, val):
+        """ Sets the debt's payment timing. """
+        self._payment_timing = when_conv(val)
 
     def min_inflow(self, when='end'):
         """ The minimum payment on the debt. """

--- a/forecaster/accounts/debt.py
+++ b/forecaster/accounts/debt.py
@@ -3,7 +3,7 @@
 from decimal import Decimal
 from forecaster.accounts.base import Account
 from forecaster.ledger import Money
-from forecaster.utility import frequency_conv, when_conv
+from forecaster.utility import Timing
 
 class Debt(Account):
     """ A debt with a balance and an interest rate.
@@ -32,15 +32,8 @@ class Debt(Account):
             Debts may be accelerated by as much as possible by setting
             this argument to `Money('Infinity')`, or non-accelerated
             by setting this argument to `Money(0)`.
-        payment_frequency (int): The number of times each year that
-            payments are due. Uses the same syntax as
-            `forecaster.utility.frequency_conv` (e.g. 'M' or 12
-            for monthly payments).
-            Optional; defaults to monthly payments.
-        payment_timing (str, int): When payments are made in each
-            payment period (e.g. 'start', 'end', 0.5). Uses the same
-            syntax as `forecaster.utility.when_conv`.
-            Optional; defaults to 'end'.
+        payment_timing (Timing, dict[float, float]): The timings of
+            payments and the weight of each payment timing. Optional.
     """
 
     def __init__(
@@ -49,7 +42,7 @@ class Debt(Account):
             inputs=None, initial_year=None, minimum_payment=Money(0),
             living_expense=Money(0), savings_rate=1,
             accelerated_payment=Money('Infinity'),
-            payment_frequency='M', payment_timing='end',
+            payment_timing=None,
             **kwargs):
         """ Constructor for `Debt`. """
 
@@ -64,8 +57,6 @@ class Debt(Account):
         self._living_expense = None
         self._savings_rate = None
         self._accelerated_payment = None
-        self._payment_frequency = None
-        self._payment_timing = None
 
         # Apply generic Account logic:
         super().__init__(
@@ -77,7 +68,9 @@ class Debt(Account):
         self.living_expense = living_expense
         self.savings_rate = savings_rate
         self.accelerated_payment = accelerated_payment
-        self.payment_frequency = payment_frequency
+
+        if payment_timing is None:
+            payment_timing = Timing()
         self.payment_timing = payment_timing
 
         # Debt must have a negative balance
@@ -123,26 +116,6 @@ class Debt(Account):
     @accelerated_payment.setter
     def accelerated_payment(self, val):
         self._accelerated_payment = Money(val)
-
-    @property
-    def payment_frequency(self):
-        """ The number of times a year that payments are due. """
-        return self._payment_frequency
-
-    @payment_frequency.setter
-    def payment_frequency(self, val):
-        """ Sets the debt's payment frequency. """
-        self._payment_frequency = frequency_conv(val)
-
-    @property
-    def payment_timing(self):
-        """ When the debt's payments are due in each payment period. """
-        return self._payment_timing
-
-    @payment_timing.setter
-    def payment_timing(self, val):
-        """ Sets the debt's payment timing. """
-        self._payment_timing = when_conv(val)
 
     def min_inflow(self, when='end'):
         """ The minimum payment on the debt. """

--- a/forecaster/accounts/debt.py
+++ b/forecaster/accounts/debt.py
@@ -128,7 +128,7 @@ class Debt(Account):
         """ The maximum annual withdrawals from the debt account. """
         return Money(0)
 
-    def max_inflows(self, timing=None, _balance=Money(0)):
+    def max_inflows(self, timing=None, balance_limit=None, inflow_limit=None):
         """ The maximum amounts that can be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -140,24 +140,27 @@ class Debt(Account):
         Args:
             timing (Timing): A mapping of `{when: weight}` pairs.
                 Optional. Uses default_timing if not provided.
-            _balance (Money): The balance that the method will seek to
-                achieve by end-of-year. This is primarily provided for
-                the benefit of certain subclasses (like `Debt`) which
-                calculate inflows and outflows relative to a zero point
-                different than a conventional Account. For example,
-                inflows to a Debt move its balance toward $0, not
-                $Infinity. Optional.
+            balance_limit (Money): This balance, if provided, will not
+                be exceeded at year-end. Optional.
+            inflow_limit (Money): Total inflows will not exceed this
+                amount (not including any inflows already recorded
+                against this `Account`). Optional.
 
         Returns:
             dict[float, Money]: A mapping of `{when: value}` pairs where
                 `value` indicates the maximum amount that can be
                 contributed at that time.
         """
-        # This method provides a different default for _balance, so
-        # it isn't a useless method.
-        return super().max_inflows(timing=timing, _balance=_balance)
+        if balance_limit is None:
+            # Only pay off debts until they reach $0 balance.
+            # (Superclass assumes we want to contribute indefinitely.)
+            balance_limit = Money(0)
+        return super().max_inflows(
+            timing=timing,
+            balance_limit=balance_limit,
+            inflow_limit=inflow_limit)
 
-    def min_inflows(self, timing=None, _balance=Money(0)):
+    def min_inflows(self, timing=None, balance_limit=None, inflow_limit=None):
         """ The minimum amounts that must be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -169,22 +172,25 @@ class Debt(Account):
         Args:
             timing (Timing): A mapping of `{when: weight}` pairs.
                 Optional. Uses default_timing if not provided.
-            _balance (Money): The balance that the method will seek to
-                achieve by end-of-year. This is primarily provided for
-                the benefit of certain subclasses (like `Debt`) which
-                calculate inflows and outflows relative to a zero point
-                different than a conventional Account. For example,
-                inflows to a Debt move its balance toward $0, not
-                $Infinity. Optional.
+            balance_limit (Money): This balance, if provided, will not
+                be exceeded at year-end. Optional.
+            inflow_limit (Money): Total inflows will not exceed this
+                amount (not including any inflows already recorded
+                against this `Account`). Optional.
 
         Returns:
             dict[float, Money]: A mapping of `{when: value}` pairs where
                 `value` indicates the maximum amount that can be
                 contributed at that time.
         """
-        # This method provides a different default for _balance, so
-        # it isn't a useless method.
-        return super().min_inflows(timing=timing, _balance=_balance)
+        if balance_limit is None:
+            # Only pay off debts until they reach $0 balance.
+            # (Superclass assumes we want to contribute indefinitely.)
+            balance_limit = Money(0)
+        return super().min_inflows(
+            timing=timing,
+            balance_limit=balance_limit,
+            inflow_limit=inflow_limit)
 
     def max_payment(
             self, savings_available=Money(0),

--- a/forecaster/accounts/debt.py
+++ b/forecaster/accounts/debt.py
@@ -128,7 +128,8 @@ class Debt(Account):
         """ The maximum annual withdrawals from the debt account. """
         return Money(0)
 
-    def max_inflows(self, timing=None, balance_limit=None, inflow_limit=None):
+    def max_inflows(
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The maximum amounts that can be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -142,8 +143,8 @@ class Debt(Account):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): This balance, if provided, will not
                 be exceeded at year-end. Optional.
-            inflow_limit (Money): Total inflows will not exceed this
-                amount (not including any inflows already recorded
+            transaction_limit (Money): Total inflows will not exceed
+                this amount (not including any inflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -158,9 +159,10 @@ class Debt(Account):
         return super().max_inflows(
             timing=timing,
             balance_limit=balance_limit,
-            inflow_limit=inflow_limit)
+            transaction_limit=transaction_limit)
 
-    def min_inflows(self, timing=None, balance_limit=None, inflow_limit=None):
+    def min_inflows(
+            self, timing=None, balance_limit=None, transaction_limit=None):
         """ The minimum amounts that must be contributed at `timing`.
 
         The output transaction values will be proportionate to the
@@ -174,8 +176,8 @@ class Debt(Account):
                 Optional. Uses default_timing if not provided.
             balance_limit (Money): This balance, if provided, will not
                 be exceeded at year-end. Optional.
-            inflow_limit (Money): Total inflows will not exceed this
-                amount (not including any inflows already recorded
+            transaction_limit (Money): Total inflows will not exceed
+                this amount (not including any inflows already recorded
                 against this `Account`). Optional.
 
         Returns:
@@ -190,7 +192,7 @@ class Debt(Account):
         return super().min_inflows(
             timing=timing,
             balance_limit=balance_limit,
-            inflow_limit=inflow_limit)
+            transaction_limit=transaction_limit)
 
     def max_payment(
             self, savings_available=Money(0),

--- a/forecaster/canada/accounts/rrsp.py
+++ b/forecaster/canada/accounts/rrsp.py
@@ -142,7 +142,7 @@ class RRSP(RegisteredAccount):
         else:
             # Only withdrawals in excess of the minimum RRIF withdrawal
             # are hit by the withholding tax.
-            taxable_income = self.taxable_income - self.min_outflow
+            taxable_income = self.taxable_income - self.min_outflow_limit
 
         year = nearest_year(
             constants.RRSP_WITHHOLDING_TAX_RATE,
@@ -208,7 +208,7 @@ class RRSP(RegisteredAccount):
             return min(accrual, Money(max_accrual)) + rollover
 
     @property
-    def min_outflow(self):
+    def min_outflow_limit(self):
         """ Minimum annual RRSP/RRIF withdrawal """
         # Minimum withdrawals are required the year after converting to
         # an RRIF. How it is calculated depends on the person's age.

--- a/forecaster/canada/accounts/rrsp.py
+++ b/forecaster/canada/accounts/rrsp.py
@@ -207,8 +207,9 @@ class RRSP(RegisteredAccount):
             rollover = self.contribution_room - self.inflows
             return min(accrual, Money(max_accrual)) + rollover
 
-    def min_outflow(self, when='end'):
-        """ Minimum RRSP withdrawal """
+    @property
+    def min_outflow(self):
+        """ Minimum annual RRSP/RRIF withdrawal """
         # Minimum withdrawals are required the year after converting to
         # an RRIF. How it is calculated depends on the person's age.
         if self.rrif_conversion_year < self.this_year:

--- a/forecaster/canada/accounts/taxable_account.py
+++ b/forecaster/canada/accounts/taxable_account.py
@@ -1,4 +1,4 @@
-""" TODO """
+""" Provides a Canadian taxable investment account. """
 
 from forecaster.accounts import Account
 from forecaster.ledger import (
@@ -34,7 +34,8 @@ class TaxableAccount(Account):
 
     def __init__(
             self, owner, balance=0, rate=0,
-            nper=1, inputs=None, initial_year=None, acb=None, **kwargs):
+            nper=1, inputs=None, initial_year=None, default_timing=None,
+            acb=None, **kwargs):
         """ Constructor for `TaxableAccount`.
 
         See documentation for `Account` for information on args not
@@ -50,7 +51,8 @@ class TaxableAccount(Account):
 
         super().__init__(
             owner=owner, balance=balance, rate=rate, nper=nper,
-            inputs=inputs, initial_year=initial_year, **kwargs)
+            inputs=inputs, initial_year=initial_year,
+            default_timing=default_timing, **kwargs)
 
         # If acb wasn't provided, assume there have been no capital
         # gains or losses, so acb = balance.

--- a/forecaster/canada/accounts/tfsa.py
+++ b/forecaster/canada/accounts/tfsa.py
@@ -1,4 +1,4 @@
-""" TODO """
+""" Provides a Canadian tax-free savings account. """
 
 from forecaster.canada.accounts.registered_account import RegisteredAccount
 from forecaster.ledger import Money, recorded_property
@@ -11,6 +11,7 @@ class TFSA(RegisteredAccount):
 
     def __init__(self, owner, balance=0, rate=0,
                  nper=1, inputs=None, initial_year=None,
+                 default_timing=None,
                  contribution_room=None, contributor=None,
                  inflation_adjust=None, **kwargs):
         """ Initializes a TFSA object.
@@ -32,6 +33,7 @@ class TFSA(RegisteredAccount):
         super().__init__(
             owner, balance=balance, rate=rate,
             nper=nper, inputs=inputs, initial_year=initial_year,
+            default_timing=default_timing,
             contribution_room=contribution_room, contributor=contributor,
             **kwargs)
 

--- a/forecaster/canada/forecaster.py
+++ b/forecaster/canada/forecaster.py
@@ -1,63 +1,33 @@
 """ Provides a Canada-specific implementation of Forecaster. """
 
-from forecaster.forecaster import Forecaster
-from forecaster.canada.accounts import RRSP, TFSA, TaxableAccount
+from forecaster.forecaster import Forecaster, Parameter
 from forecaster.canada.tax import TaxCanada
 from forecaster.canada.settings import SettingsCanada
 
 
+# Override the arguments for initializing tax_treatment, since
+# ForecasterCanada uses TaxCanada instead of Tax.
+DEFAULTVALUES = {
+    str(Parameter.TAX_TREATMENT): {
+        "inflation_adjust": "scenario.inflation_adjust",
+        "province": "settings.tax_province"}
+}
+
+# This maps each of the above parameters to a type:
+DEFAULTTYPES = {str(Parameter.TAX_TREATMENT): TaxCanada}
+
 class ForecasterCanada(Forecaster):
     """ Tests Forecaster (Canada). """
 
-    def __init__(self, settings=SettingsCanada, **kwargs):
+    def __init__(self, *args, settings=None, **kwargs):
         """ Inits Forecaster with Canada-specific settings.
 
         In addition to using a Canada-specific Settings object by
         default, this class also provides Canada-specific defaults and
         init logic for RRSPs, TFSAs, TaxableAccounts, and Tax objects.
         """
-        super().__init__(settings=settings, **kwargs)
-
-    def add_rrsp(
-            self, inflation_adjust=None, rrif_conversion_year=None, cls=RRSP,
-            **kwargs):
-        """ Adds an RRSP to the forecast. """
-        self.set_kwarg(
-            kwargs, 'inflation_adjust', inflation_adjust,
-            self.scenario.inflation_adjust)
-        self.set_kwarg(
-            kwargs, 'rrif_conversion_year', rrif_conversion_year, None)
-        return self.add_contribution_limit_account(cls=cls, **kwargs)
-
-    def add_tfsa(
-            self, inflation_adjust=None, cls=TFSA, **kwargs):
-        """ Adds a TFSA to the forecast. """
-        self.set_kwarg(
-            kwargs, 'inflation_adjust', inflation_adjust,
-            self.scenario.inflation_adjust)
-        return self.add_contribution_limit_account(cls=cls, **kwargs)
-
-    def add_taxable_account(
-            self, acb=None, cls=TaxableAccount, **kwargs):
-        """ Adds a TaxableAccount to the forecast. """
-        self.set_kwarg(kwargs, 'acb', acb, None)
-        return self.add_asset(cls=cls, **kwargs)
-
-    def set_tax_treatment(
-            self, inflation_adjust=None, province=None, cls=TaxCanada,
-            **kwargs):
-        """ Sets tax treatment for the forecast.
-
-        Overrides set_tax_treatment to deal with different parameter
-        list for canada.tax objects.
-        """
-        # canada.tax has a different call signature than forecaster.tax,
-        # so it's appropriate for this method to take different args.
-        # pylint: disable=arguments-differ
-
-        self.set_kwarg(
-            kwargs, 'inflation_adjust', inflation_adjust,
-            self.scenario.inflation_adjust)
-        self.set_kwarg(kwargs, 'province', province, None)
-        self.tax_treatment = cls(**kwargs)
-        return self.tax_treatment
+        if settings is None:
+            settings = SettingsCanada()
+        super().__init__(*args, settings=settings, **kwargs)
+        self.default_values.update(DEFAULTVALUES)
+        self.default_types.update(DEFAULTTYPES)

--- a/forecaster/canada/settings.py
+++ b/forecaster/canada/settings.py
@@ -15,12 +15,15 @@ class SettingsCanada(Settings):
     # pylint: disable=too-few-public-methods
 
     """ Override transaction strategy weights for Canadian accounts. """
-    transaction_in_weights = {
+    contribution_weights = {
         'RRSP': 1, 'TFSA': 2, 'TaxableAccount': 3
     }
-    transaction_out_weights = {
+    withdrawal_weights = {
         'RRSP': 1, 'TFSA': 2, 'SavingsAccount': 3
     }
+
+    """ TaxCanada defaults """
+    tax_province = "BC"
 
     """ RESP defaults """
     resp_child_other_income = 0

--- a/forecaster/forecast/contribution.py
+++ b/forecaster/forecast/contribution.py
@@ -49,7 +49,7 @@ class ContributionForecast(SubForecast):
         for account in self.account_transactions:
             self.add_transaction(
                 value=self.account_transactions[account],
-                timings=timings,
+                timing=timings,
                 from_account=available,
                 to_account=account)
 

--- a/forecaster/forecast/contribution.py
+++ b/forecaster/forecast/contribution.py
@@ -3,6 +3,7 @@
 from forecaster.ledger import (
     recorded_property, recorded_property_cached)
 from forecaster.forecast.subforecast import SubForecast
+from forecaster.utility import Timing
 
 class ContributionForecast(SubForecast):
     """ A forecast of each year's contributions to various accounts.
@@ -41,18 +42,16 @@ class ContributionForecast(SubForecast):
         super().update_available(available)
 
         # NOTE: We assume here contributions are made monthly.
-
+        timings = Timing(when=0.5, frequency=12)
         # pylint: disable=not-an-iterable,unsubscriptable-object
         # pylint can't infer the type of account_transactions
         # because we don't import `AccountTransactionsStrategy`
         for account in self.account_transactions:
             self.add_transaction(
                 value=self.account_transactions[account],
-                when=0.5,
-                frequency=12,
+                timings=timings,
                 from_account=available,
-                to_account=account
-            )
+                to_account=account)
 
     @recorded_property_cached
     def account_transactions(self):
@@ -62,8 +61,7 @@ class ContributionForecast(SubForecast):
         """
         return self.account_transaction_strategy(
             total=self.total_available,
-            accounts=self.accounts
-        )
+            accounts=self.accounts)
 
     @recorded_property
     def contributions(self):

--- a/forecaster/forecast/contribution.py
+++ b/forecaster/forecast/contribution.py
@@ -72,4 +72,5 @@ class ContributionForecast(SubForecast):
         # pylint can't infer the type of account_transactions
         # because we don't import `AccountTransactionsStrategy`
         return sum(
-            self.account_transactions[account] for account in self.accounts)
+            self.account_transactions[account]
+            for account in self.account_transactions)

--- a/forecaster/forecast/income.py
+++ b/forecaster/forecast/income.py
@@ -14,6 +14,8 @@ class IncomeForecast(SubForecast):
 
             Note that all `Person` objects must have the same
             `this_year` attribute, as must their various accounts.
+        asset_sale_timing (Timing): The timing of asset sales.
+            Optional.
 
     Attributes:
         asset_sale (Money): The proceeds from a sale of property.
@@ -29,9 +31,9 @@ class IncomeForecast(SubForecast):
     """
 
     def __init__(
-            self, initial_year, people):
+            self, initial_year, people, asset_sale_timing=None):
         """ Initializes an instance of IncomeForecast. """
-        super().__init__(initial_year)
+        super().__init__(initial_year, default_timing=asset_sale_timing)
         # Invoke Ledger's __init__ or pay the price!
         # Store input values
         self.people = people
@@ -42,13 +44,9 @@ class IncomeForecast(SubForecast):
         # started on doing the updates:
         super().update_available(available)
 
-        # TODO: Determine timing of asset sale. (see #32)
-        # Also: should this receive an Account (e.g. other_assets)
-        # as the `from_account`?
+        # TODO: Move money into available from an `Asset` account  #32
         self.add_transaction(
             value=self.asset_sale,
-            # TODO Determine timing of asset sale #32
-            # timings=None,
             from_account=None,  # TODO Move money from asset account #32
             to_account=available
         )
@@ -57,7 +55,7 @@ class IncomeForecast(SubForecast):
         for person in self.people:
             self.add_transaction(
                 person.net_income,
-                timings=person.payment_timing,
+                timing=person.payment_timing,
                 from_account=None, to_account=available)
 
     @recorded_property

--- a/forecaster/forecast/income.py
+++ b/forecaster/forecast/income.py
@@ -47,7 +47,8 @@ class IncomeForecast(SubForecast):
         # as the `from_account`?
         self.add_transaction(
             value=self.asset_sale,
-            when=0.5,  # TODO Determine timing of asset sale #32
+            # TODO Determine timing of asset sale #32
+            # timings=None,
             from_account=None,  # TODO Move money from asset account #32
             to_account=available
         )
@@ -56,8 +57,7 @@ class IncomeForecast(SubForecast):
         for person in self.people:
             self.add_transaction(
                 person.net_income,
-                when=person.payment_timing,
-                frequency=person.payment_frequency,
+                timings=person.payment_timing,
                 from_account=None, to_account=available)
 
     @recorded_property

--- a/forecaster/forecast/income.py
+++ b/forecaster/forecast/income.py
@@ -52,14 +52,11 @@ class IncomeForecast(SubForecast):
             to_account=available
         )
 
-        # Record income monthly.
-        # NOTE: This code assumes income is received at the end of
-        # each payment period. Consider whether some cases (like
-        # biweekly payments) might justify using the midpoint of
-        # each period.
+        # Record income according to the Persons' payment schedules:
         for person in self.people:
             self.add_transaction(
-                person.net_income, when=0.5,
+                person.net_income,
+                when=person.payment_timing,
                 frequency=person.payment_frequency,
                 from_account=None, to_account=available)
 

--- a/forecaster/forecast/living_expenses.py
+++ b/forecaster/forecast/living_expenses.py
@@ -53,8 +53,7 @@ class LivingExpensesForecast(SubForecast):
         for person in self.people:
             self.add_transaction(
                 self.living_expenses * income_weights[person],
-                when=person.payment_timing,
-                frequency=person.payment_frequency,
+                timings=person.payment_timing,
                 from_account=available, to_account=None)
 
     @recorded_property_cached

--- a/forecaster/forecast/living_expenses.py
+++ b/forecaster/forecast/living_expenses.py
@@ -53,7 +53,7 @@ class LivingExpensesForecast(SubForecast):
         for person in self.people:
             self.add_transaction(
                 self.living_expenses * income_weights[person],
-                timings=person.payment_timing,
+                timing=person.payment_timing,
                 from_account=available, to_account=None)
 
     @recorded_property_cached

--- a/forecaster/forecast/reduction.py
+++ b/forecaster/forecast/reduction.py
@@ -106,7 +106,10 @@ class ReductionForecast(SubForecast):
                 base=debt.inflows)
             # Turn these into weights so that we can multiply each
             # transaction in `account_transactions` by it:
-            savings_weight = savings_total / total_payment
+            if total_payment != 0:
+                savings_weight = savings_total / total_payment
+            else:
+                savings_weight = 0
             payments[debt] = {
                 when: value * savings_weight
                 for when, value in transactions.items()}

--- a/forecaster/forecast/reduction.py
+++ b/forecaster/forecast/reduction.py
@@ -3,6 +3,7 @@
 from forecaster.ledger import (
     Money, recorded_property, recorded_property_cached)
 from forecaster.forecast.subforecast import SubForecast
+from forecaster.utility import Timing
 
 class ReductionForecast(SubForecast):
     """ A forecast of each year's contribution reductions.
@@ -53,35 +54,30 @@ class ReductionForecast(SubForecast):
         # First determine miscellaneous other reductions.
         # (These take priority because they're generally user-input.)
         # Assume we make these payments at the end of each month.
+        other_timings = Timing(when=1, frequency=12)
         self.add_transaction(
             value=self.reduction_from_other,
-            when='end',
-            frequency=12,
+            timings=other_timings,
             from_account=available,
-            to_account=None
-        )
+            to_account=None)
 
         # Apply debt payment transactions:
         for debt in self.account_transactions:
             # Track the savings portion against `available`:
             self.add_transaction(
                 value=self.payments_from_available[debt],
-                when=debt.payment_timing,
-                frequency=debt.payment_frequency,
+                timings=debt.payment_timing,
                 from_account=available,
-                to_account=debt
-            )
+                to_account=debt)
             # Track the non-savings portion as well, but don't deduct
             # from `available`
             self.add_transaction(
                 value=(
                     self.account_transactions[debt]
                     - self.payments_from_available[debt]),
-                when=debt.payment_timing,
-                frequency=debt.payment_frequency,
+                timings=debt.payment_timing,
                 from_account=None,
-                to_account=debt
-            )
+                to_account=debt)
 
     @recorded_property_cached
     def account_transactions(self):

--- a/forecaster/forecast/reduction.py
+++ b/forecaster/forecast/reduction.py
@@ -52,10 +52,10 @@ class ReductionForecast(SubForecast):
 
         # First determine miscellaneous other reductions.
         # (These take priority because they're generally user-input.)
-        # Assume we make these payments monthly.
+        # Assume we make these payments at the end of each month.
         self.add_transaction(
             value=self.reduction_from_other,
-            when=0.5,
+            when='end',
             frequency=12,
             from_account=available,
             to_account=None
@@ -66,7 +66,7 @@ class ReductionForecast(SubForecast):
             # Track the savings portion against `available`:
             self.add_transaction(
                 value=self.payments_from_available[debt],
-                when=0.5,
+                when=debt.payment_timing,
                 frequency=debt.payment_frequency,
                 from_account=available,
                 to_account=debt
@@ -77,7 +77,7 @@ class ReductionForecast(SubForecast):
                 value=(
                     self.account_transactions[debt]
                     - self.payments_from_available[debt]),
-                when=0.5,
+                when=debt.payment_timing,
                 frequency=debt.payment_frequency,
                 from_account=None,
                 to_account=debt

--- a/forecaster/forecast/subforecast.py
+++ b/forecaster/forecast/subforecast.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from collections.abc import Hashable
+from decimal import Decimal
 from forecaster.ledger import Ledger, Money, recorded_property
 from forecaster.accounts import Account
 from forecaster.utility import Timing
@@ -262,7 +263,9 @@ class SubForecast(Ledger):
         if not isinstance(value, Money):
             value = Money(value)
         if timings is None:
-            timing = Timing()
+            # TODO: Add default_timings to this class and use that here
+            # instead of a new Timing object?
+            timings = Timing()
 
         # For convenience, ensure that we're withdrawing from
         # from_account and depositing to to_account:
@@ -276,8 +279,9 @@ class SubForecast(Ledger):
         # Add a transaction at each timing, with a transaction value
         # proportionate to the (normalized) weight for its timing:
         for timing, weight in timings.items():
+            weighted_value = value * Decimal(weight / total_weight)
             self._add_transaction(
-                value=value * (weight / total_weight), when=timing,
+                value=weighted_value, when=timing,
                 from_account=from_account, to_account=to_account,
                 strict_timing=strict_timing)
 

--- a/forecaster/forecast/subforecast.py
+++ b/forecaster/forecast/subforecast.py
@@ -374,10 +374,10 @@ class SubForecast(Ledger):
         available to be withdrawn from the account at the time of each
         existing transaction and also at `when`.
 
-        The method also attemptes to interpolate additional times between
+        The method also attempts to interpolate additional times between
         the existing transactions where the amount available to be
         withdrawn is equal to `target_value`. Due to implementation
-        limitations, the exact timing is not guaranteed to ne found
+        limitations, the exact timing is not guaranteed to be found
         (but for most Account types it will be found exactly.)
 
         Returns:

--- a/forecaster/forecast/withdrawal.py
+++ b/forecaster/forecast/withdrawal.py
@@ -74,7 +74,7 @@ class WithdrawalForecast(SubForecast):
         # and withdraw whenever we dip into negative balance.
         for when in sorted(available.keys()):
             accum += available[when]
-            timings = Timing(when=when)
+            timing = Timing(when=when)
             if accum < 0:  # negative balance - time to withdraw!
                 # Withdraw however much we're short by:
                 withdrawal = -accum
@@ -88,7 +88,7 @@ class WithdrawalForecast(SubForecast):
                     # (not accounting for withholdings):
                     self.add_transaction(
                         value=account_transaction,
-                        timings=timings,
+                        timing=timing,
                         from_account=account,
                         to_account=available,
                         strict_timing=True
@@ -101,7 +101,7 @@ class WithdrawalForecast(SubForecast):
                     if new_withholding > 0:
                         self.add_transaction(
                             value=new_withholding,
-                            timings=timings,
+                            timing=timing,
                             from_account=available,
                             to_account=None,
                             strict_timing=True

--- a/forecaster/forecaster.py
+++ b/forecaster/forecaster.py
@@ -59,12 +59,10 @@ DEFAULTVALUES = {
         "inflation_adjust": "scenario.inflation_adjust"},
     str(Parameter.CONTRIBUTION_STRATEGY): {
         "strategy": "settings.contribution_strategy",
-        "weights": "settings.contribution_weights",
-        "timing": "settings.contribution_timing"},
+        "weights": "settings.contribution_weights"},
     str(Parameter.WITHDRAWAL_STRATEGY): {
         "strategy": "settings.withdrawal_strategy",
-        "weights": "settings.withdrawal_weights",
-        "timing": "settings.withdrawal_timing"},
+        "weights": "settings.withdrawal_weights"},
     str(Parameter.ALLOCATION_STRATEGY): {
         "strategy": "settings.allocation_strategy",
         "target": "settings.allocation_target",
@@ -74,8 +72,7 @@ DEFAULTVALUES = {
         "risk_transition_period": "settings.allocation_risk_trans_period",
         "adjust_for_retirement_plan": "settings.allocation_adjust_retirement"},
     str(Parameter.DEBT_PAYMENT_STRATEGY): {
-        "strategy": "settings.debt_payment_strategy",
-        "timing": "settings.debt_payment_timing"},
+        "strategy": "settings.debt_payment_strategy"},
     str(Parameter.TAX_TREATMENT): {
         "tax_brackets": "settings.tax_brackets",
         "personal_deduction": "settings.tax_personal_deduction",

--- a/forecaster/forecaster.py
+++ b/forecaster/forecaster.py
@@ -342,7 +342,7 @@ class Forecaster(object):
         if param_name in self.default_values:
             # Get the default mapping for this parameter:
             # (We copy it to avoid mutating it)
-            default_values = copy(DEFAULTVALUES[param_name])
+            default_values = copy(self.default_values[param_name])
             # Replace each value with the value of the same-named
             # attribute of the `Forecaster` object:
             for key, value in default_values.items():

--- a/forecaster/ledger/base.py
+++ b/forecaster/ledger/base.py
@@ -1,4 +1,4 @@
-""" TODO """
+""" Module providing the Ledger base type and associated classes. """
 
 import inspect
 from forecaster.ledger.money import Money
@@ -149,7 +149,7 @@ class TaxSource(Ledger):
         """ Taxable income for the given year.
 
         Subclasses should override this method rather than the
-        taxable_income and _taxable_income_history properties.
+        _taxable_income and _taxable_income_history properties.
         """
         return Money(0)
 
@@ -158,7 +158,7 @@ class TaxSource(Ledger):
         """ Tax withheld for the given year.
 
         Subclasses should override this method rather than the
-        tax_withheld and _tax_withheld_history properties.
+        _tax_withheld and _tax_withheld_history properties.
         """
         return Money(0)
 
@@ -167,7 +167,7 @@ class TaxSource(Ledger):
         """ Tax credit for the given year.
 
         Subclasses should override this method rather than the
-        tax_credit and _tax_credit_history properties.
+        _tax_credit and _tax_credit_history properties.
         """
         return Money(0)
 
@@ -176,6 +176,6 @@ class TaxSource(Ledger):
         """ Tax deduction for the given year.
 
         Subclasses should override this method rather than the
-        tax_deduction and _tax_deduction_history properties.
+        _tax_deduction and _tax_deduction_history properties.
         """
         return Money(0)

--- a/forecaster/person.py
+++ b/forecaster/person.py
@@ -6,11 +6,45 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta
 from forecaster.ledger import (
     Money, TaxSource, recorded_property, recorded_property_cached)
-from forecaster.utility import frequency_conv, when_conv
+from forecaster.utility import Timing
 
 
 class Person(TaxSource):
     """ Represents a person's basic information: age and retirement age.
+
+    Arguments:
+        name (str): The person's name. No specific form is required;
+            this is only used for display, not any computations.
+        birth_date (datetime, str, int): The person's birth date.
+            May be passed as an int (interpreted as the birth year) or
+            as a datetime-convertible value (e.g. a string in a
+            suitable format)
+        retirement_date (datetime, str, int): The person's retirement
+            date. Optional.
+            May be passed as an int (interpreted as the birth year) or
+            as a datetime-convertible value (e.g. a string in a
+            suitable format)
+        gross_income (Money): Annual gross income for the initial year.
+        raise_rate (Decimal, Callable): The person's raise in gross
+            income for each year relative to the previous year.
+        payment_timing (Timing, dict[float, float]): The timings of
+            payments mapped to the weight of each payment. Optional.
+        spouse (Person): The person's spouse. This linkage is
+            one-to-one; the spouse's `spouse` attribute points back to
+            this Person.
+        tax_treatment (Tax): The tax treatment of the person. A callable
+            object; see documentation for `Tax` for more information.
+        inputs (dict[str, dict[int, Any]]): `{attr: {year: val}}`
+            pairs, where `attr` is any one of `Person`'s recorded
+            propertes, namely:
+
+            * taxable_income
+            * tax_withheld
+            * tax_credit
+            * tax_deduction
+            * gross_income
+            * net_income
+            * raise_rate
 
     Attributes:
         accounts (set): All accounts naming this Person as an owner.
@@ -38,15 +72,8 @@ class Person(TaxSource):
             year relative to last year.
         raise_rate_history (dict[int, Decimal]): Raises for all years
             on record.
-        payment_frequency (str, int): The frequency with which
-            `Person` is paid. Uses the same syntax as
-            `forecaster.utility.frequency_conv` (e.g. 'M' or 12
-            for monthly payments).
-            Optional; defaults to biweekly payments.
-        payment_timing (str, int): When payments are made in each
-            payment period (e.g. 'start', 'end', 0.5). Uses the same
-            syntax as `forecaster.utility.when_conv`.
-            Optional; defaults to 'end'.
+        payment_timing (Timing, dict[float, float]): The timings of
+            payments and the weight of each payment timing. Optional.
         spouse (Person): The person's spouse. This linkage is
             one-to-one; the spouse's `spouse` attribute points back to
             this Person.
@@ -78,94 +105,32 @@ class Person(TaxSource):
     def __init__(
             self, initial_year, name, birth_date, retirement_date=None,
             gross_income=0, raise_rate=0, spouse=None, tax_treatment=None,
-            payment_frequency='BW', payment_timing='end', inputs=None):
-        """ Constructor for `Person`.
-
-        Attributes:
-            accounts (set): All accounts naming this Person as an owner.
-
-        Args:
-            initial_year (int): The first year of recorded data.
-            name (str): The person's name.
-            birth_date (datetime): The person's date of birth.
-                May be passed as any value that can be cast to str and
-                converted to datetime by python-dateutils.parse().
-            retirement_date (datetime): The person's retirement date.
-                May be passed as any value that can be cast to str and
-                converted to datetime by python-dateutils.parse().
-                Optional.
-            gross_income (Money): The person's gross income in
-                `initial_year`.
-            raise_rate (dict[int, Decimal], callable): The person's
-                raise for each year, as a callable object with the
-                signature `raise_rate(year)` or a dict of
-                `{year: raise}` pairs. The raise is a Decimal
-                interpreted as a percentage (e.g. `Decimal('0.03')`
-                indicates a 3% raise).
-            spouse (Person): The person's spouse. Optional.
-                In ordinary use, the first person of the couple is
-                constructed with `spouse=None`, and the second person is
-                constructed with `spouse=person1`. Both persons will
-                automatically have their spouse attribute updated to
-                point at each other.
-            tax_treatment (Tax): The person's tax treatment. Optional.
-                This can be any callable object that accepts the form
-                `tax_treatment(taxable_income, year)` and returns a
-                Money object (which corresponds to total taxes payable
-                on `taxable_income`).
-            payment_frequency (str, int): The frequency with which
-                `Person` is paid. Uses the same syntax as
-                `forecaster.utility.frequency_conv` (e.g. 'M' or 12
-                for monthly payments).
-                Optional; defaults to biweekly payments.
-            payment_timing (str, int): When payments are made in each
-                payment period (e.g. 'start', 'end', 0.5). Uses the same
-                syntax as `forecaster.utility.when_conv`.
-                Optional; defaults to 'end'.
-            inputs (dict[str, dict[int, Any]]): `{attr: {year: val}}`
-                pairs, where `attr` is any one of `Person`'s recorded
-                propertes, namely:
-
-                * taxable_income
-                * tax_withheld
-                * tax_credit
-                * tax_deduction
-                * gross_income
-                * net_income
-                * raise_rate
-
-        Returns:
-            An instance of class `Person`
-
-        Raises:
-            ValueError: birth_date or retirement_date are not parseable
-                as dates.
-            ValueError: retirement_date precedes birth_date
-            OverflowError: birth_date or retirement_date are too large.
-
-        """
+            payment_timing=None, inputs=None):
+        """ Initializes a `Person` object. """
         super().__init__(initial_year=initial_year, inputs=inputs)
+
+        # For simple, non-property-wrapped attributes, assign directly:
+        self.name = name
+        if payment_timing is None:
+            # Timing is technically mutable, so init it here rather than
+            # using "Timing()" as a default value.
+            payment_timing = Timing()
+        self.payment_timing = payment_timing
 
         # For attributes wrapped by ordinary properties, create hidden
         # attributes and assign to them using the properties:
-        self._name = None
         self._birth_date = None
         self._retirement_date = None
-        self._raise_rate_function = None
+        self._raise_rate_callable = None
         self._spouse = None
         self._tax_treatment = None
-        self._payment_frequency = None
-        self._payment_timing = None
         self._contribution_room = {}
         self._contribution_groups = {}
-        self.name = name
         self.birth_date = birth_date
         self.retirement_date = retirement_date
         self.raise_rate_callable = raise_rate
         self.spouse = spouse
         self.tax_treatment = tax_treatment
-        self.payment_frequency = payment_frequency
-        self.payment_timing = payment_timing
 
         # Now provide initial-year values for recorded properties:
         # NOTE: Be sure to do type-checking here.
@@ -175,16 +140,6 @@ class Person(TaxSource):
 
         # Finally, build an empty set for accounts to add themselves to.
         self.accounts = set()
-
-    @property
-    def name(self):
-        """ The name of the Person. """
-        return self._name
-
-    @name.setter
-    def name(self, val):
-        """ Sets the Person's name. """
-        self._name = str(val)
 
     @property
     def birth_date(self):
@@ -264,7 +219,7 @@ class Person(TaxSource):
             callable: A function with signature
             `raise_rate(year) -> Decimal`.
         """
-        return self._raise_rate_function
+        return self._raise_rate_callable
 
     @raise_rate_callable.setter
     def raise_rate_callable(self, val):
@@ -287,10 +242,10 @@ class Person(TaxSource):
                 def func(_=None):
                     """ Wraps value in a function with an optional arg. """
                     return val
-            self._raise_rate_function = func
+            self._raise_rate_callable = func
         else:
             # If the input is callable, use it without modification.
-            self._raise_rate_function = val
+            self._raise_rate_callable = val
 
     @property
     def spouse(self):
@@ -336,26 +291,6 @@ class Person(TaxSource):
         else:
             raise TypeError('Person: tax_treatment must be callable or None.')
 
-    @property
-    def payment_frequency(self):
-        """ The number of times a year that Person is paid. """
-        return self._payment_frequency
-
-    @payment_frequency.setter
-    def payment_frequency(self, val):
-        """ Sets the Person's payment frequency. """
-        self._payment_frequency = frequency_conv(val)
-
-    @property
-    def payment_timing(self):
-        """ When the Person is paid in each payment period. """
-        return self._payment_timing
-
-    @payment_timing.setter
-    def payment_timing(self, val):
-        """ Sets the Person's payment timing. """
-        self._payment_timing = when_conv(val)
-
     # pylint: disable=method-hidden
     # Pylint gets confused by attributes added by metaclass.
     # This method isn't hidden in __init__; it's assigned to (by a
@@ -390,7 +325,7 @@ class Person(TaxSource):
     @recorded_property_cached
     def raise_rate(self):
         """ The `Person`'s raise for the current year. """
-        return self._raise_rate_function(self.this_year)
+        return self._raise_rate_callable(self.this_year)
 
     def contribution_room(self, account):
         """ The contribution room for the given account.

--- a/forecaster/person.py
+++ b/forecaster/person.py
@@ -122,8 +122,9 @@ class Person(TaxSource):
         if payment_timing is None:
             # Timing is technically mutable, so init it here rather than
             # using "Timing()" as a default value.
-            payment_timing = Timing()
-        self.payment_timing = payment_timing
+            self.payment_timing = Timing()
+        else:
+            self.payment_timing = Timing(payment_timing)
 
         # For attributes wrapped by ordinary properties, create hidden
         # attributes and assign to them using the properties:

--- a/forecaster/settings.py
+++ b/forecaster/settings.py
@@ -51,12 +51,10 @@ class Settings:
     ''' ContributionStrategy defaults '''
     contribution_strategy = 'Ordered'
     contribution_weights = {'Account': 1}
-    contribution_timing = 'end'
 
     ''' WithdrawalStrategy defaults '''
     withdrawal_strategy = 'Ordered'
     withdrawal_weights = {'Account': 1}
-    withdrawal_timing = 'end'
 
     ''' AllocationStrategy defaults '''
     allocation_strategy = 'n-age'
@@ -69,7 +67,6 @@ class Settings:
 
     ''' DebtPaymentStrategy defaults '''
     debt_payment_strategy = 'Avalanche'
-    debt_payment_timing = 'end'
 
     ''' Tax defaults '''
     tax_brackets = {initial_year: {Decimal(0): Decimal(0)}}

--- a/forecaster/strategy/account_transaction.py
+++ b/forecaster/strategy/account_transaction.py
@@ -186,9 +186,9 @@ class AccountTransactionStrategy(Strategy):
         # until we hit the total.
         for account in accounts_ordered:
             if total >= 0:
-                transaction = min(total, account.max_inflow())
+                transaction = min(total, account.max_inflow)
             else:
-                transaction = max(total, account.max_outflow())
+                transaction = max(total, account.max_outflow)
             transactions[account] = transaction
             total -= transaction
 
@@ -239,15 +239,15 @@ class AccountTransactionStrategy(Strategy):
         # outflows that aren't met by the allocation in `transactions`.
         if total > 0:  # For inflows, check min_inflow and max_inflow
             override_transactions = {
-                account: account.min_inflow() for account in transactions
-                if account.min_inflow() > transactions[account]
+                account: account.min_inflow for account in transactions
+                if account.min_inflow > transactions[account]
             }
         else:
             # For outflows, check min_outflow.
             # (Recall that outflows are negative-valued)
             override_transactions = {
-                account: account.min_outflow() for account in transactions
-                if account.min_outflow() < transactions[account]
+                account: account.min_outflow for account in transactions
+                if account.min_outflow < transactions[account]
             }
 
         # If there are no accounts that need to be tweaked, we're done.
@@ -274,11 +274,11 @@ class AccountTransactionStrategy(Strategy):
            remaining_total == 0:
             if total > 0:  # Inflows
                 override_transactions = {
-                    account: account.min_inflow()
+                    account: account.min_inflow
                     for account in remaining_accounts}
             else:  # Outflows
                 override_transactions = {
-                    account: account.min_outflow()
+                    account: account.min_outflow
                     for account in remaining_accounts}
             return override_transactions
 
@@ -299,15 +299,15 @@ class AccountTransactionStrategy(Strategy):
         # outflows that aren't met by the allocation in `transactions`.
         if total > 0:  # For inflows, check min_inflow and max_inflow
             override_transactions = {
-                account: account.max_inflow() for account in transactions
-                if account.max_inflow() < transactions[account]
+                account: account.max_inflow for account in transactions
+                if account.max_inflow < transactions[account]
             }
         else:
             # For outflows, check max_outflow.
             # (Recall that outflows are negative-valued)
             override_transactions = {
-                account: account.max_outflow() for account in transactions
-                if account.max_outflow() > transactions[account]
+                account: account.max_outflow for account in transactions
+                if account.max_outflow > transactions[account]
             }
 
         # If there are no accounts that need to be tweaked, we're done.
@@ -514,9 +514,9 @@ class AccountTransactionStrategy(Strategy):
             # TODO: Deal with timings for inflows and outflows, since
             # the amount that we can move in/out is timing-dependent:
             if total >= 0:
-                limit = account.max_inflow()
+                limit = account.max_inflow
             else:
-                limit = account.max_outflow()
+                limit = account.max_outflow
             # Cap transaction amount at the limit if it's too large:
             if Money('-Infinity') < limit < Money('Infinity'):
                 finite_accounts[account] = limit

--- a/forecaster/strategy/debt_payment.py
+++ b/forecaster/strategy/debt_payment.py
@@ -1,6 +1,5 @@
 """ Provides a class for determining schedules of debt payments. """
 
-from decimal import Decimal
 from forecaster.strategy.base import Strategy, strategy_method
 from forecaster.ledger import Money
 
@@ -21,12 +20,6 @@ class DebtPaymentStrategy(Strategy):
             * "Snowball"
             * "Avalanche"
 
-        timing (str, Decimal): Transactions are modelled as lump sums
-            which take place at this time.
-
-            This is expressed according to the `when` convention
-            described in `ledger.Account`.
-
     Args:
         available (Money): The total amount available for repayment
             across all accounts.
@@ -37,17 +30,6 @@ class DebtPaymentStrategy(Strategy):
         is one of the input accounts and each Money object is a
         transaction for that account.
     """
-
-    def __init__(self, strategy, timing='end'):
-        """ Constructor for DebtPaymentStrategy. """
-
-        super().__init__(strategy)
-
-        self.timing = timing
-
-        # NOTE: We leave it to calling code to interpret str-valued
-        # timing. (We could convert to `When` here - consider it.)
-        self._param_check(self.timing, 'timing', (Decimal, str))
 
     def _strategy_ordered(self, sorted_debts, available, assign_minimums=True):
         """ Proposes transactions based on an ordered list of debts.
@@ -74,7 +56,8 @@ class DebtPaymentStrategy(Strategy):
                 # Add the minimum payment (this method accounts for
                 # any pre-existing inflows and only returns the
                 # minimum *additional* inflows)
-                transactions[debt] += debt.min_inflow(when=self.timing)
+                # TODO: Deal with timing
+                transactions[debt] += debt.min_inflow()
                 # And reduce the amount available for further payments
                 # based on this debt's savings/living expenses settings:
                 available -= debt.payment_from_savings(
@@ -92,8 +75,9 @@ class DebtPaymentStrategy(Strategy):
             # left:
             payment = debt.payment(
                 savings_available=available,
-                other_payments=transactions[debt],
-                when=self.timing
+                other_payments=transactions[debt]
+                # TODO: Deal with timing
+                # when=self.timing
             )
 
             # Reduce the pool of money remaining for further

--- a/forecaster/utility.py
+++ b/forecaster/utility.py
@@ -38,7 +38,14 @@ class Timing(dict):
         """ Initializes a Timing dict. """
         # Get an empty dict:
         super().__init__()
-        # Process arguments to ensure they're numeric:
+        # If we call Timing(input) with dict-type `input`, copy the
+        # input without further processing:
+        if isinstance(when, dict):
+            self.update(when)
+            return
+        # Otherwise, assume inputs are scalar and build out multiple
+        # timings accordingly.
+        # Arguments might be str-valued; process to make them numeric:
         when = when_conv(when)
         frequency = frequency_conv(frequency)
         # Each transaction has equal weight:

--- a/forecaster/utility.py
+++ b/forecaster/utility.py
@@ -73,17 +73,25 @@ class Timing(dict):
             if all(value >= 0 for value in when.values()):
                 self.update(when)
                 return
+            # If all items are negative, flip the signs and then copy:
+            elif all(value <= 0 for value in when.values()):
+                self.update({time: -value for time, value in when.items()})
+                return
 
-            # Otherwise, we need to account for negative values.
-            # We do this in two stages. First, for each timing,
-            # determine the cumulative value of all transactions to date
-            # and store it in `accum`:
+            # Otherwise, we need to account for sequences of inflows and
+            # outflows. We'll assume that positive net flows correspond
+            # to the amounts available at any given time and treat these
+            # as our weights; this lets us ingest an `available` dict.
+
+            # We do this in two stages.
+            # First, for each timing, determine the cumulative value of
+            # all transactions to date and store it in `accum`:
             accum = {}
             tally = 0  # sum of transactions so far
             for timing in sorted(when.keys()):
                 tally += when[timing]
                 accum[timing] = tally
-            # Now iterate over the timings *again*, this time
+            # Second, iterate over the timings *again*, this time
             # determining for each timing the maximum amount that can be
             # withdrawn without putting a future timing into negative
             # balance:

--- a/forecaster/utility.py
+++ b/forecaster/utility.py
@@ -38,8 +38,9 @@ class Timing(dict):
         """ Initializes a Timing dict. """
         # Get an empty dict:
         super().__init__()
-        # Process `when` to ensure it's numeric:
+        # Process arguments to ensure they're numeric:
         when = when_conv(when)
+        frequency = frequency_conv(frequency)
         # Each transaction has equal weight:
         weight = 1 / frequency
         # Build the dict:

--- a/forecaster/utility.py
+++ b/forecaster/utility.py
@@ -7,6 +7,46 @@ modules.
 import collections
 from decimal import Decimal
 
+
+class Timing(dict):
+    """ A dict of {timing: weight} pairs.
+
+    This is really just a vanilla dict with a convenient init method.
+    It divides the interval [0,1] into a number of equal-length periods
+    equal to `frequency` and, within each period, assigns a timing at
+    `when`. The timings are equally-weighted.
+
+    Examples:
+        Timing()
+        # {0.5: 1}
+        Timing(when=1, frequency=4)
+        # {0.25: 0.25, 0.5: 0.25, 0.75: 0.25, 1: 0.25}
+        Timing(when=0, frequency=4)
+        # {0: 0.25, 0.25: 0.25, 0.5: 0.25, 0.75: 0.25}
+        Timing(when=0.5, frequency=2)
+        # {0.25: 0.5, 0.75: 0.5}
+
+    Args:
+        when (Number, str): When transactions occur in each period (e.g.
+            'start', 'end', 0.5). Uses the same syntax as
+            `forecaster.utility.when_conv`. Optional.
+        frequency (str, int): The number of periods (and thus the number
+            of transactions). Uses the same syntax as
+            `forecaster.utility.frequency_conv`. Optional.
+    """
+    def __init__(self, when=0.5, frequency=1):
+        """ Initializes a Timing dict. """
+        # Get an empty dict:
+        super().__init__()
+        # Process `when` to ensure it's numeric:
+        when = when_conv(when)
+        # Each transaction has equal weight:
+        weight = 1 / frequency
+        # Build the dict:
+        for time in range(frequency):
+            self[(time + when) / frequency] = weight
+
+
 def when_conv(when):
     """ Converts various types of `when` inputs to Decimal.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 py-moneyed~=0.7.0
-python-dateutil~=2.7.3
+python-dateutil~=2.8.0

--- a/tests/canada/test_accounts/test_principle_residence.py
+++ b/tests/canada/test_accounts/test_principle_residence.py
@@ -13,10 +13,10 @@ class TestPrincipleResidenceMethods(TestAccountMethods):
         super().setUp()
         self.AccountType = PrincipleResidence
 
-    def test_taxable_income(self, *args, **kwargs):
-        """ Test PrincipleResidence.taxable_income. """
+    def test_taxable_income_gain(self, *args, **kwargs):
+        """ Test PrincipleResidence.taxable_income with a gain. """
         account = self.AccountType(
-            self.owner, *args, balance=1000, rate=1, nper=1)
+            self.owner, *args, balance=1000, rate=1, nper=1, **kwargs)
         self.assertEqual(account.taxable_income, Money(0))
         # Now let the residence appreciate 100% (to $2000) and then sell
         # the home (i.e. withdraw $2000):
@@ -29,4 +29,5 @@ if __name__ == '__main__':
     # as exceptions (instead of returning "NaN"). It is lower-precision than
     # ExtendedContext, which is the default.
     decimal.setcontext(decimal.BasicContext)
-    unittest.main()
+    unittest.TextTestRunner().run(
+        unittest.TestLoader().loadTestsFromName(__name__))

--- a/tests/canada/test_accounts/test_registered_account.py
+++ b/tests/canada/test_accounts/test_registered_account.py
@@ -117,10 +117,8 @@ class TestRegisteredAccountMethods(TestContributionLimitAccountMethods):
         self.assertEqual(account.inflation_adjust(2003), Decimal(1.75))
         self.assertEqual(account.inflation_adjust(2017), Decimal(2))
 
-    def test_init_invalid(self, *args, **kwargs):
-        """ Test calling __init__ with invalid inputs. """
-        super().test_init_invalid(*args, **kwargs)
-        # Try invalid inflation_adjustments.
+    def test_init_invalid_infl_adj(self, *args, **kwargs):
+        """ Test calling __init__ with invalid inflation_adjustment. """
         # First, pass in a non-dict
         with self.assertRaises(TypeError):
             self.AccountType(

--- a/tests/canada/test_accounts/test_rrsp.py
+++ b/tests/canada/test_accounts/test_rrsp.py
@@ -426,7 +426,7 @@ class TestRRSPMethods(TestRegisteredAccountMethods):
             # If this isn't an RRIF yet, there's no min. outflow.
             else:
                 min_outflow = 0
-            self.assertEqual(account.min_outflow(), min_outflow)
+            self.assertEqual(account.min_outflow_limit(), min_outflow)
             # Advance the account and test again on the next year:
             account.next_year()
 
@@ -525,11 +525,11 @@ class TestRRSPMethods(TestRegisteredAccountMethods):
         # should equal the annual accrual for `self.owner` (without
         # carryover, since we used up all contribution room last year):
         self.assertEqual(
-            spousal_account.max_inflow,
+            spousal_account.max_inflow_limit,
             Money(10000) * constants.RRSP_ACCRUAL_RATE)
         self.assertEqual(
-            regular_account.max_inflow,
-            spousal_account.max_inflow)
+            regular_account.max_inflow_limit,
+            spousal_account.max_inflow_limit)
 
 if __name__ == '__main__':
     # NOTE: BasicContext is useful for debugging, as most errors are treated

--- a/tests/canada/test_accounts/test_rrsp.py
+++ b/tests/canada/test_accounts/test_rrsp.py
@@ -525,11 +525,11 @@ class TestRRSPMethods(TestRegisteredAccountMethods):
         # should equal the annual accrual for `self.owner` (without
         # carryover, since we used up all contribution room last year):
         self.assertEqual(
-            spousal_account.max_inflow(),
+            spousal_account.max_inflow,
             Money(10000) * constants.RRSP_ACCRUAL_RATE)
         self.assertEqual(
-            regular_account.max_inflow(),
-            spousal_account.max_inflow())
+            regular_account.max_inflow,
+            spousal_account.max_inflow)
 
 if __name__ == '__main__':
     # NOTE: BasicContext is useful for debugging, as most errors are treated

--- a/tests/forecast/test_base.py
+++ b/tests/forecast/test_base.py
@@ -4,7 +4,7 @@ import unittest
 from copy import copy
 from decimal import Decimal
 from forecaster import (
-    Money, Person, Forecast, Tax, Scenario,
+    Money, Person, Forecast, Tax, Scenario, Timing,
     Account, AccountTransactionStrategy, ContributionForecast)
 
 class DummyForecast(object):
@@ -84,6 +84,7 @@ class TestForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # One person, to own the account:
+        timing = Timing(frequency='BW')
         self.person = Person(
             initial_year=self.initial_year,
             name="Test",
@@ -91,7 +92,7 @@ class TestForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # An account for savings to go to:
         self.account = Account(
             owner=self.person)
@@ -174,7 +175,8 @@ class TestForecast(unittest.TestCase):
             Money(0),
             Money(600),
             Money(600)]
-        self.assertEqual(results, target)
+        for first, second in zip(results, target):
+            self.assertAlmostEqual(first, second, places=2)
 
     def test_multi_year(self):
         """ Tests a multi-year forecast. """
@@ -202,7 +204,8 @@ class TestForecast(unittest.TestCase):
             Money(0),
             Money(360),
             Money(720)]
-        self.assertEqual(results, target)
+        for first, second in zip(results, target):
+            self.assertAlmostEqual(first, second, places=2)
 
 if __name__ == '__main__':
     unittest.TextTestRunner().run(

--- a/tests/forecast/test_contribution.py
+++ b/tests/forecast/test_contribution.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from forecaster import (
     Money, Person, Tax,
     ContributionForecast, AccountTransactionStrategy,
-    Account, ContributionLimitAccount)
+    Account, ContributionLimitAccount, Timing)
 
 
 class TestContributionForecast(unittest.TestCase):
@@ -19,6 +19,7 @@ class TestContributionForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # Accounts need an owner:
+        timing = Timing(frequency='BW')
         self.person = Person(
             initial_year=self.initial_year,
             name="Test",
@@ -26,7 +27,7 @@ class TestContributionForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # We want at least two accounts which are contributed to
         # in different orders depending on the strategy.
         self.account = Account(

--- a/tests/forecast/test_contribution.py
+++ b/tests/forecast/test_contribution.py
@@ -68,10 +68,10 @@ class TestContributionForecast(unittest.TestCase):
         # pylint: disable=unsubscriptable-object
         # These properties return dicts, but pylint has trouble
         # inferring that.
-        account_contribution = (
-            self.forecast.account_transactions[self.account])
-        limit_account_contribution = (
-            self.forecast.account_transactions[self.limit_account])
+        account_contribution = sum(
+            self.forecast.account_transactions[self.account].values())
+        limit_account_contribution = sum(
+            self.forecast.account_transactions[self.limit_account].values())
         # We have $3000 available to contribute. We contribute the
         # first $1000 to `limit_account` and the balance to `account`
         self.assertEqual(
@@ -94,10 +94,10 @@ class TestContributionForecast(unittest.TestCase):
         # pylint: disable=unsubscriptable-object
         # These properties return dicts, but pylint has trouble
         # inferring that.
-        account_contribution = (
-            self.forecast.account_transactions[self.account])
-        limit_account_contribution = (
-            self.forecast.account_transactions[self.limit_account])
+        account_contribution = sum(
+            self.forecast.account_transactions[self.account].values())
+        limit_account_contribution = sum(
+            self.forecast.account_transactions[self.limit_account].values())
         # We have $3000 available to contribute. We contribute $500
         # to `limit_account` and the rest to `account`.
         self.assertEqual(

--- a/tests/forecast/test_income.py
+++ b/tests/forecast/test_income.py
@@ -3,7 +3,7 @@
 import unittest
 from decimal import Decimal
 from forecaster import (
-    Money, Person, IncomeForecast, Tax)
+    Money, Person, IncomeForecast, Tax, Timing)
 
 
 class TestIncomeForecast(unittest.TestCase):
@@ -16,6 +16,7 @@ class TestIncomeForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # A person who is paid $200 gross ($100 net) every 2 weeks:
+        timing = Timing(frequency='BW')
         self.person1 = Person(
             initial_year=self.initial_year,
             name="Test 1",
@@ -23,7 +24,7 @@ class TestIncomeForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # A person who is paid $100 gross ($50 net) every 2 weeks:
         self.person2 = Person(
             initial_year=self.initial_year,
@@ -32,7 +33,7 @@ class TestIncomeForecast(unittest.TestCase):
             retirement_date="31 December 2047",
             gross_income=Money(2600),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         self.forecast = IncomeForecast(
             initial_year=self.initial_year,
             people={self.person1, self.person2})
@@ -76,9 +77,10 @@ class TestIncomeForecast(unittest.TestCase):
         # Assuming there are no other inflows or outflows (and, since
         # this is the first year, there shouldn't be as there are no
         # carryovers), the sum of inflows should be 150*26=3900
-        self.assertEqual(
+        self.assertAlmostEqual(
             sum(self.forecast.transactions[available].values()),
-            Money(3900))
+            Money(3900),
+            places=2)
 
 if __name__ == '__main__':
     unittest.TextTestRunner().run(

--- a/tests/forecast/test_living_expenses.py
+++ b/tests/forecast/test_living_expenses.py
@@ -4,7 +4,7 @@ import unittest
 from decimal import Decimal
 from forecaster import (
     Money, Person, LivingExpensesForecast,
-    LivingExpensesStrategy, Tax)
+    LivingExpensesStrategy, Tax, Timing)
 
 
 class TestLivingExpensesForecast(unittest.TestCase):
@@ -17,6 +17,7 @@ class TestLivingExpensesForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # A person who is paid $200 gross ($100 net) every 2 weeks:
+        timing = Timing(frequency='BW')
         self.person1 = Person(
             initial_year=self.initial_year,
             name="Test 1",
@@ -24,7 +25,7 @@ class TestLivingExpensesForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # A person who is paid $100 gross ($50 net) every 2 weeks:
         self.person2 = Person(
             initial_year=self.initial_year,
@@ -33,7 +34,7 @@ class TestLivingExpensesForecast(unittest.TestCase):
             retirement_date="31 December 2047",
             gross_income=Money(2600),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # Track inflows from employment:
         self.available = {
             Decimal(0.5 + i) / 26: Money(150)
@@ -149,9 +150,10 @@ class TestLivingExpensesForecast(unittest.TestCase):
         self.forecast.update_available(self.available)
         # There should $3900 in living expenses deducted from $7800 in
         # net income, for net available of $3900.
-        self.assertEqual(
+        self.assertAlmostEqual(
             sum(self.forecast.transactions[self.available].values()),
-            Money(-3900))
+            Money(-3900),
+            places=2)
 
 if __name__ == '__main__':
     unittest.TextTestRunner().run(

--- a/tests/forecast/test_reduction.py
+++ b/tests/forecast/test_reduction.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from collections import defaultdict
 from forecaster import (
     Money, Person, ReductionForecast,
-    DebtPaymentStrategy, Debt, Tax)
+    DebtPaymentStrategy, Debt, Tax, Timing)
 
 
 class TestReductionForecast(unittest.TestCase):
@@ -18,6 +18,7 @@ class TestReductionForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # Debt accounts need an owner:
+        timing = Timing(frequency='BW')
         self.person = Person(
             initial_year=self.initial_year,
             name="Test",
@@ -25,7 +26,7 @@ class TestReductionForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # We want at least two debt accounts which are repaid
         # in different orders depending on whether the strategy
         # is avalanche or snowball.
@@ -33,14 +34,14 @@ class TestReductionForecast(unittest.TestCase):
             owner=self.person,
             balance=Money(-1000),  # Low balance ($1000)
             rate=Decimal(0),  # Low interest (0%)
-            payment_frequency='M',  # Monthly payments
+            payment_timing=Timing(frequency='M'),  # Monthly payments
             minimum_payment=Money(10)
         )
         self.debt_large = Debt(
             owner=self.person,
             balance=Money(-5000),  # High balance ($5000)
             rate=Decimal(1),  # High interest (100%)
-            payment_frequency='BM',  # Bimonthly payments
+            payment_timing=Timing(frequency='BM'),  # Bimonthly payments
             minimum_payment=Money(20)
         )
         # For additional tests, set up a debt where the

--- a/tests/forecast/test_subforecast.py
+++ b/tests/forecast/test_subforecast.py
@@ -4,7 +4,7 @@ import unittest
 from collections import defaultdict
 from decimal import Decimal
 from forecaster import (
-    Money, Person, Account, SubForecast)
+    Money, Person, Account, SubForecast, Timing)
 from forecaster.forecast.subforecast import TransactionDict
 
 
@@ -73,7 +73,7 @@ class TestSubForecast(unittest.TestCase):
         self.available_dict[Decimal(0)] = Money(100)
         # Move all $100 to account1 right away:
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_dict, to_account=self.account1)
         # Transactions should be recorded against both available_dict
         # and account1:
@@ -92,7 +92,7 @@ class TestSubForecast(unittest.TestCase):
         # Try to move $100 in cash to account1 at the start of the year
         # (i.e. before cash is actually on-hand):
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_acct, to_account=self.account2)
         # Transaction should be delayed until mid-year:
         self.assertEqual(
@@ -107,7 +107,7 @@ class TestSubForecast(unittest.TestCase):
         # Move $100 in cash (which comes from the untracked pool None)
         # to account2 at the start of the year:
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=None, to_account=self.account2)
         # Transactions should be recorded against both:
         self.assertEqual(
@@ -123,7 +123,7 @@ class TestSubForecast(unittest.TestCase):
         self.available_dict[Decimal(0)] = Money(100)
         # Move all $100 to account1 right away:
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_dict, to_account=self.account1)
         # The $100 inflow at the start time should be reduced to $0:
         self.assertEqual(
@@ -141,7 +141,7 @@ class TestSubForecast(unittest.TestCase):
 
         # Move all $100 to account1 right away:
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_acct,
             to_account=self.account2)
         # No more money should be available:
@@ -159,7 +159,7 @@ class TestSubForecast(unittest.TestCase):
         self.account1[Decimal(0)] = Money(100)
         # Move $100 from account1 to account2 right away:
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.account1, to_account=self.account2)
         # The $100 inflow at the start time should be reduced to $0:
         self.assertEqual(
@@ -176,10 +176,10 @@ class TestSubForecast(unittest.TestCase):
         # when cash isn't actually available until mid-year:
         self.available_dict[Decimal(0.5)] = Money(100)
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_dict, to_account=self.account2)
         # Transaction should be recorded against existing transaction
-        # at when=0.5, resulting in no net transaction:
+        # at timing=0.5, resulting in no net transaction:
         self.assertEqual(
             self.available_dict[Decimal(0.5)],
             Money(0))
@@ -196,7 +196,7 @@ class TestSubForecast(unittest.TestCase):
         # Try to move $100 in cash to account1 at the start of the year
         # (i.e. before cash is actually on-hand):
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_acct, to_account=self.account2)
         # Transactions should be delayed until mid-year:
         self.assertEqual(
@@ -215,7 +215,7 @@ class TestSubForecast(unittest.TestCase):
 
         # Move $100 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=100, when=0.5,
+            value=100, timing=0.5,
             from_account=self.available_dict, to_account=self.account2)
         # Transaction should occur on-time:
         self.assertEqual(
@@ -230,7 +230,7 @@ class TestSubForecast(unittest.TestCase):
 
     def test_add_trans_future_neg(self):
         """ Transaction that would cause future negative balance. """
-        # Want to have $100 available at when=0.5 and at when=1,
+        # Want to have $100 available at timing=0.5 and at timing=1,
         # but with >$100 in-between:
         self.available_dict[Decimal(0)] = Money(50)
         self.available_dict[Decimal(0.5)] = Money(50)
@@ -239,7 +239,7 @@ class TestSubForecast(unittest.TestCase):
 
         # Try to move $100 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=100, when=0.5,
+            value=100, timing=0.5,
             from_account=self.available_dict, to_account=self.account2)
         # Transaction should be delayed to year-end:
         self.assertEqual(
@@ -256,7 +256,7 @@ class TestSubForecast(unittest.TestCase):
         self.account1[Decimal(0)] = Money(100)
         # Move $150 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=150, when=0.5,
+            value=150, timing=0.5,
             from_account=self.account1, to_account=self.account2)
         # Check net transaction flows of available cash:
         self.assertEqual(
@@ -275,7 +275,7 @@ class TestSubForecast(unittest.TestCase):
         self.account1[Decimal(1)] = Money(100)
         # Move $150 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=150, when=0.5,
+            value=150, timing=0.5,
             from_account=self.account1, to_account=self.account2)
         # Check net transaction flows of available cash:
         self.assertEqual(
@@ -295,7 +295,7 @@ class TestSubForecast(unittest.TestCase):
 
         # Try to move $100 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=100, when=0.5,
+            value=100, timing=0.5,
             from_account=self.available_dict, to_account=self.account2)
         # Transaction should occur immediately:
         self.assertEqual(
@@ -315,7 +315,7 @@ class TestSubForecast(unittest.TestCase):
 
         # Try to move $100 in cash to account2 at mid-year:
         self.subforecast.add_transaction(
-            value=100, when=0.5,
+            value=100, timing=0.5,
             from_account=self.available_acct, to_account=self.account2)
         # Transaction should occur immediately:
         self.assertEqual(
@@ -333,7 +333,7 @@ class TestSubForecast(unittest.TestCase):
         # timing to force it through:
         self.available_dict[Decimal(0.5)] = Money(100)
         self.subforecast.add_transaction(
-            value=100, when='start',
+            value=100, timing='start',
             from_account=self.available_dict, to_account=self.account2,
             strict_timing=True)
         # Transaction should done at the time requested:
@@ -344,6 +344,18 @@ class TestSubForecast(unittest.TestCase):
         self.assertEqual(
             self.account2[Decimal(0)],
             Money(100))
+
+    def test_add_trans_timing_basic(self):
+        """ Add a number of transactions based on a Timing object. """
+        # Add $50 at when=0.5 and $50 at when=1
+        timing = Timing(when=1, frequency=2)
+        self.subforecast.add_transaction(
+            value=100, timing=timing,
+            to_account=self.available_dict)
+        # Confirm monies were added at the times noted above:
+        self.assertEqual(
+            self.available_dict,
+            {Decimal(0.5): Money(50), Decimal(1): Money(50)})
 
 if __name__ == '__main__':
     unittest.TextTestRunner().run(

--- a/tests/forecast/test_subforecast.py
+++ b/tests/forecast/test_subforecast.py
@@ -94,13 +94,12 @@ class TestSubForecast(unittest.TestCase):
         self.subforecast.add_transaction(
             value=100, timing='start',
             from_account=self.available_acct, to_account=self.account2)
+        result = self.subforecast.transactions
+        target = {
+            self.available_acct: {Decimal(0.5): Money(-100)},
+            self.account2: {Decimal(0.5): Money(100)}}
         # Transaction should be delayed until mid-year:
-        self.assertEqual(
-            self.subforecast.transactions,
-            {
-                self.available_acct: {Decimal(0.5): Money(-100)},
-                self.account2: {Decimal(0.5): Money(100)}
-            })
+        self.assertEqual(result, target)
 
     def test_transaction_none(self):
         """ Tests that transactions against None are saved correctly. """

--- a/tests/forecast/test_tax.py
+++ b/tests/forecast/test_tax.py
@@ -3,7 +3,7 @@
 import unittest
 from decimal import Decimal
 from forecaster import (
-    Money, Person, TaxForecast, Tax, Account)
+    Money, Person, TaxForecast, Tax, Account, Timing)
 
 
 class TestTaxForecast(unittest.TestCase):
@@ -16,6 +16,7 @@ class TestTaxForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # A person who is paid $1000 gross ($500 withheld):
+        timing = Timing(frequency='BW')
         self.person1 = Person(
             initial_year=self.initial_year,
             name="Test 1",
@@ -23,7 +24,7 @@ class TestTaxForecast(unittest.TestCase):
             retirement_date="31 December 2045",
             gross_income=Money(1000),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # A person who is paid $500 gross ($250 withheld):
         self.person2 = Person(
             initial_year=self.initial_year,
@@ -32,7 +33,7 @@ class TestTaxForecast(unittest.TestCase):
             retirement_date="31 December 2047",
             gross_income=Money(500),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # An account owned by person1 with $100 to withdraw
         self.account1 = Account(
             owner=self.person1,

--- a/tests/forecast/test_withdrawal.py
+++ b/tests/forecast/test_withdrawal.py
@@ -70,10 +70,10 @@ class TestWithdrawalForecast(unittest.TestCase):
         # pylint: disable=unsubscriptable-object
         # These properties return dicts, but pylint has trouble
         # inferring that.
-        account_withdrawal = (
-            self.forecast.account_transactions[self.account])
-        limit_account_withdrawal = (
-            self.forecast.account_transactions[self.limit_account])
+        account_withdrawal = sum(
+            self.forecast.account_transactions[self.account].values())
+        limit_account_withdrawal = sum(
+            self.forecast.account_transactions[self.limit_account].values())
         # We are withdrawing $20,000. We'll withdraw the whole balance
         # of `limit_account` ($6000), with the rest from `account`:
         self.assertEqual(
@@ -96,10 +96,10 @@ class TestWithdrawalForecast(unittest.TestCase):
         # pylint: disable=unsubscriptable-object
         # These properties return dicts, but pylint has trouble
         # inferring that.
-        account_withdrawal = (
-            self.forecast.account_transactions[self.account])
-        limit_account_withdrawal = (
-            self.forecast.account_transactions[self.limit_account])
+        account_withdrawal = sum(
+            self.forecast.account_transactions[self.account].values())
+        limit_account_withdrawal = sum(
+            self.forecast.account_transactions[self.limit_account].values())
         # We are withdrawing $20,000. We'll withdraw $3000 from
         # `limit_account`, with the rest from `account`:
         self.assertEqual(

--- a/tests/forecast/test_withdrawal.py
+++ b/tests/forecast/test_withdrawal.py
@@ -3,7 +3,7 @@
 import unittest
 from decimal import Decimal
 from forecaster import (
-    Money, Person, Tax,
+    Money, Person, Tax, Timing,
     WithdrawalForecast,
     AccountTransactionStrategy,
     Account, ContributionLimitAccount)
@@ -19,6 +19,7 @@ class TestWithdrawalForecast(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # Accounts need an owner:
+        timing = Timing(frequency='BW')
         self.person = Person(
             initial_year=self.initial_year,
             name="Test",
@@ -26,7 +27,7 @@ class TestWithdrawalForecast(unittest.TestCase):
             retirement_date="31 December 1999",  # last year
             gross_income=Money(5200),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=timing)
         # We want at least two accounts which are withdrawn from
         # in different orders depending on the strategy.
         self.account = Account(

--- a/tests/strategy/test_debt_payment.py
+++ b/tests/strategy/test_debt_payment.py
@@ -48,37 +48,41 @@ class TestDebtPaymentStrategies(unittest.TestCase):
         self.excess = Money(10)
 
     @staticmethod
-    def min_payment(debts, timing):
+    def min_payment(debts):
         """ Finds the minimum payment *from savings* for `accounts`. """
-        # Find the minimum payment *from savings* for each account:
-        return sum(
-            max(
-                (debt.min_inflow(timing) - debt.living_expense)
-                * debt.savings_rate,
-                Money(0)
-            )
-            for debt in debts
-        )
+        payment = Money(0)
+        for debt in debts:
+            # This used to be a genexp, but it's been split up to allow
+            # for easier inspection.
+            inflows = debt.min_inflows()
+            inflows_non_living = sum(inflows.values()) - debt.living_expense
+            inflows_savings = inflows_non_living * debt.savings_rate
+            payment += max(inflows_savings, Money(0))
+        return payment
 
     @staticmethod
-    def max_payment(debts, timing):
-        """ Finds the maximum payment *from savings* for `accounts`. """
-        # Find the minimum payment *from savings* for each account:
-        return sum(
-            max(
-                (debt.max_inflow(timing) - debt.living_expense)
-                * debt.savings_rate,
-                Money(0)
-            )
-            for debt in debts
-        )
+    def max_payment(debts):
+        """ Finds the maximum payment *from savings* for `debts`. """
+        payment = Money(0)
+        for debt in debts:
+            # This used to be a genexp, but it's been split up to allow
+            # for easier inspection.
+            inflows = debt.max_inflows()
+            inflows_non_living = sum(inflows.values()) - debt.living_expense
+            inflows_savings = inflows_non_living * debt.savings_rate
+            payment += max(inflows_savings, Money(0))
+        return payment
 
     def test_snowball_min_payment(self):
         """ Test strategy_snowball with the minimum payment only. """
-        payment = self.min_payment(self.debts, self.strategy_snowball.timing)
+        # Inflows will exactly match minimum payments:
+        payment = self.min_payment(self.debts)
         results = self.strategy_snowball(self.debts, payment)
         for debt in self.debts:
-            self.assertEqual(results[debt], debt.minimum_payment)
+            self.assertAlmostEqual(
+                sum(results[debt].values()),
+                debt.minimum_payment,
+                places=4)
 
     def test_snowball_less_than_min(self):
         """ Test strategy_snowball with less than the minimum payments. """
@@ -86,103 +90,98 @@ class TestDebtPaymentStrategies(unittest.TestCase):
         payment = Money(0)
         results = self.strategy_snowball(self.debts, payment)
         for debt in self.debts:
-            self.assertEqual(results[debt], debt.minimum_payment)
+            self.assertAlmostEqual(
+                sum(results[debt].values()),
+                debt.minimum_payment,
+                places=4)
 
     def test_snowball_basic(self):
         """ Test strategy_snowball with a little more than min payments. """
         # The smallest debt should be paid first.
-        payment = self.min_payment(
-            self.debts, self.strategy_snowball.timing
-        ) + self.excess
+        payment = self.min_payment(self.debts) + self.excess
         results = self.strategy_snowball(self.debts, payment)
-        self.assertEqual(
-            results[self.debt_small_low_interest],
-            self.debt_small_low_interest.minimum_payment + self.excess
-        )
+        # The smallest debt should be partially repaid:
+        self.assertAlmostEqual(
+            sum(results[self.debt_small_low_interest].values()),
+            self.debt_small_low_interest.minimum_payment + self.excess,
+            places=4)
+        # The medium-sized debt should get its minimum payments:
         self.assertEqual(
             results[self.debt_medium],
-            self.debt_medium.minimum_payment
-        )
+            self.debt_medium.min_inflows())
+        # The largest debt should get its minimum payments:
         self.assertEqual(
             results[self.debt_big_high_interest],
-            self.debt_big_high_interest.minimum_payment
-        )
+            self.debt_big_high_interest.min_inflows())
 
     def test_snowball_close_one(self):
         """ Test strategy_snowball payments to close one debt. """
         # Pay more than the first-paid debt will accomodate.
         # The excess should go to the next-paid debt (medium).
-        payment = (
-            self.min_payment(
-                self.debts - {self.debt_small_low_interest},
-                self.strategy_snowball.timing
-            ) + self.max_payment(
-                {self.debt_small_low_interest},
-                self.strategy_snowball.timing
-            ) + self.excess
-        )
+        payment = self.min_payment(
+            self.debts - {self.debt_small_low_interest})
+        payment += self.max_payment({self.debt_small_low_interest})
+        payment += self.excess
+
         results = self.strategy_snowball(self.debts, payment)
+        # The smallest debt should be fully repaid:
         self.assertEqual(
             results[self.debt_small_low_interest],
-            self.debt_small_low_interest.max_inflow(
-                self.strategy_snowball.timing)
-        )
-        self.assertEqual(
-            results[self.debt_medium],
-            self.debt_medium.minimum_payment + self.excess
-        )
+            self.debt_small_low_interest.max_inflows())
+        # The medium-sized debt should be partially repaid:
+        self.assertAlmostEqual(
+            sum(results[self.debt_medium].values()),
+            self.debt_medium.minimum_payment + self.excess,
+            places=4)
+        # The largest debt should get its minimum payments:
         self.assertEqual(
             results[self.debt_big_high_interest],
-            self.debt_big_high_interest.minimum_payment
-        )
+            self.debt_big_high_interest.min_inflows())
 
     def test_snowball_close_two(self):
         """ Test strategy_snowball with payments to close 2 debts. """
         # Pay more than the first and second-paid debts will accomodate.
         # The self.excess should go to the next-paid debt.
-        payment = (
-            self.min_payment(
-                {self.debt_big_high_interest},
-                self.strategy_snowball.timing
-            ) + self.max_payment(
-                self.debts - {self.debt_big_high_interest},
-                self.strategy_snowball.timing
-            ) + self.excess
-        )
+        payment = self.min_payment({self.debt_big_high_interest})
+        payment += self.max_payment(
+            self.debts - {self.debt_big_high_interest})
+        payment += self.excess
+
         results = self.strategy_snowball(self.debts, payment)
+        # The smallest debt should be fully repaid:
         self.assertEqual(
             results[self.debt_small_low_interest],
-            self.debt_small_low_interest.max_inflow(
-                self.strategy_snowball.timing)
-        )
+            self.debt_small_low_interest.max_inflows())
+        # The medium-size debt should be fully repaid:
         self.assertEqual(
             results[self.debt_medium],
-            self.debt_medium.max_inflow(self.strategy_snowball.timing)
-        )
-        self.assertEqual(
-            results[self.debt_big_high_interest],
-            self.debt_big_high_interest.minimum_payment + self.excess
-        )
+            self.debt_medium.max_inflows())
+        # The largest debt should be partially repaid:
+        self.assertAlmostEqual(
+            sum(results[self.debt_big_high_interest].values()),
+            self.debt_big_high_interest.minimum_payment + self.excess,
+            places=4)
 
     def test_snowball_close_all(self):
         """ Test strategy_snowball with payments to close all debts. """
         # Contribute more than the total max.
-        payment = (
-            self.max_payment(self.debts, self.strategy_snowball.timing)
-            + self.excess)
+        payment = self.max_payment(self.debts) + self.excess
         results = self.strategy_snowball(self.debts, payment)
+        # Each debt should be fully repaid:
         for debt in self.debts:
             self.assertEqual(
                 results[debt],
-                debt.max_inflow(self.strategy_snowball.timing))
+                debt.max_inflows())
 
     def test_avalanche_min_payment(self):
         """ Test strategy_avalanche with minimum payments only. """
-        payment = self.min_payment(
-            self.debts, self.strategy_avalanche.timing)
+        payment = self.min_payment(self.debts)
         results = self.strategy_avalanche(self.debts, payment)
         for debt in self.debts:
-            self.assertEqual(results[debt], debt.minimum_payment)
+            self.assertAlmostEqual(
+                sum(results[debt].values()),
+                debt.minimum_payment,
+                places=4)
 
     def test_avalanche_less_than_min(self):
         """ Test strategy_avalanche with less than the minimum payments. """
@@ -190,95 +189,87 @@ class TestDebtPaymentStrategies(unittest.TestCase):
         payment = Money(0)
         results = self.strategy_avalanche(self.debts, payment)
         for debt in self.debts:
-            self.assertEqual(results[debt], debt.minimum_payment)
+            self.assertAlmostEqual(
+                sum(results[debt].values()),
+                debt.minimum_payment,
+                places=4)
 
     def test_avalanche_basic(self):
         """ Test strategy_avalanche with a bit more than min payments. """
         # The highest-interest debt should be paid first.
-        payment = self.min_payment(
-            self.debts, self.strategy_avalanche.timing
-        ) + self.excess
+        payment = self.min_payment(self.debts) + self.excess
         results = self.strategy_avalanche(self.debts, payment)
-        self.assertEqual(
-            results[self.debt_big_high_interest],
-            self.debt_big_high_interest.minimum_payment + self.excess
-        )
-        self.assertEqual(
-            results[self.debt_medium],
-            self.debt_medium.minimum_payment
-        )
-        self.assertEqual(
-            results[self.debt_small_low_interest],
-            self.debt_small_low_interest.minimum_payment
-        )
+        self.assertAlmostEqual(
+            sum(results[self.debt_big_high_interest].values()),
+            self.debt_big_high_interest.minimum_payment + self.excess,
+            places=4)
+        self.assertAlmostEqual(
+            sum(results[self.debt_medium].values()),
+            self.debt_medium.minimum_payment,
+            places=4)
+        self.assertAlmostEqual(
+            sum(results[self.debt_small_low_interest].values()),
+            self.debt_small_low_interest.minimum_payment,
+            places=4)
 
     def test_avalanche_close_one(self):
         """ Test strategy_avalanche with payments to close one debt. """
         # Pay more than the first-paid debt will accomodate.
         # The excess should go to the next-paid debt (medium).
-        payment = (
-            self.min_payment(
-                self.debts - {self.debt_big_high_interest},
-                self.strategy_avalanche.timing
-            ) + self.max_payment(
-                {self.debt_big_high_interest},
-                self.strategy_avalanche.timing
-            ) + self.excess
-        )
+        payment = self.min_payment(self.debts - {self.debt_big_high_interest})
+        payment += self.max_payment({self.debt_big_high_interest})
+        payment += self.excess
+
         results = self.strategy_avalanche(self.debts, payment)
+        # The high interest debt should be fully repaid:
         self.assertEqual(
             results[self.debt_big_high_interest],
-            self.debt_big_high_interest.max_inflow(
-                self.strategy_avalanche.timing)
-        )
-        self.assertEqual(
-            results[self.debt_medium],
-            self.debt_medium.minimum_payment + self.excess
-        )
-        self.assertEqual(
-            results[self.debt_small_low_interest],
-            self.debt_small_low_interest.minimum_payment
-        )
+            self.debt_big_high_interest.max_inflows())
+        # The medium-interest debt should be partially repaid:
+        self.assertAlmostEqual(
+            sum(results[self.debt_medium].values()),
+            self.debt_medium.minimum_payment + self.excess,
+            places=4)
+        # The low-interest debt should receive the minimum payment:
+        self.assertAlmostEqual(
+            sum(results[self.debt_small_low_interest].values()),
+            self.debt_small_low_interest.minimum_payment,
+            places=4)
 
     def test_avalanche_close_two(self):
         """ Test strategy_avalanche with payments to close two debts. """
         # Pay more than the first and second-paid debts will accomodate.
         # The excess should go to the next-paid debt.
-        payment = (
-            self.min_payment(
-                {self.debt_small_low_interest}, self.strategy_avalanche.timing
-            ) + self.max_payment(
-                self.debts - {self.debt_small_low_interest},
-                self.strategy_avalanche.timing
-            ) + self.excess
-        )
+        payment = self.min_payment({self.debt_small_low_interest})
+        payment += self.max_payment(
+            self.debts - {self.debt_small_low_interest})
+        payment += self.excess
+
         results = self.strategy_avalanche(self.debts, payment)
+        # The high interest debt should be fully repaid:
         self.assertEqual(
             results[self.debt_big_high_interest],
-            self.debt_big_high_interest.max_inflow(
-                self.strategy_avalanche.timing)
-        )
+            self.debt_big_high_interest.max_inflows())
+        # The medium interest debt should be fully repaid:
         self.assertEqual(
             results[self.debt_medium],
-            self.debt_medium.max_inflow(self.strategy_avalanche.timing)
-        )
-        self.assertEqual(
-            results[self.debt_small_low_interest],
-            self.debt_small_low_interest.minimum_payment + self.excess
-        )
+            self.debt_medium.max_inflows())
+        # The low interest debt should be partially repaid:
+        self.assertAlmostEqual(
+            sum(results[self.debt_small_low_interest].values()),
+            self.debt_small_low_interest.minimum_payment + self.excess,
+            places=4)
 
     def test_avalanche_close_all(self):
         """ Test strategy_avalanche with payments to close all debts. """
         # Contribute more than the total max.
-        payment = self.max_payment(
-            self.debts, self.strategy_avalanche.timing
-        ) + self.excess
+        payment = self.max_payment(self.debts) + self.excess
         results = self.strategy_avalanche(self.debts, payment)
+        # All debts should be fully repaid:
         for debt in self.debts:
             self.assertEqual(
                 results[debt],
-                debt.max_inflow(self.strategy_avalanche.timing)
-            )
+                debt.max_inflows())
 
 
 class TestDebtPaymentStrategyAttributes(unittest.TestCase):
@@ -308,21 +299,26 @@ class TestDebtPaymentStrategyAttributes(unittest.TestCase):
         self.debt.accelerated_payment = Money(0)
         results = self.strategy({self.debt}, Money(100))
         # If there's no acceleration, only the minimum is paid.
-        self.assertEqual(results[self.debt], self.debt.minimum_payment)
+        self.assertEqual(results[self.debt], self.debt.min_inflows())
 
     def test_accel_payment_partial(self):
         """ Tests payments with finite, non-zero `accelerate_payment`. """
         self.debt.accelerated_payment = Money(20)
         results = self.strategy({self.debt}, Money(100))
         # Payment should be $20 more than the minimum:
-        self.assertEqual(
-            results[self.debt], self.debt.minimum_payment + Money(20))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            self.debt.minimum_payment + Money(20),
+            places=4)
 
     def test_accel_payment_infinity(self):
         """ Tests payments where `accelerate_payment=Money('Infinity')`. """
         self.debt.accelerated_payment = Money('Infinity')
         results = self.strategy({self.debt}, Money(50))
-        self.assertEqual(results[self.debt], Money(50))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            Money(50),
+            places=4)
 
     def test_savings_rate_none(self):
         """ Tests payments where `savings_rate=0`. """
@@ -330,27 +326,39 @@ class TestDebtPaymentStrategyAttributes(unittest.TestCase):
         results = self.strategy({self.debt}, Money(50))
         # If savings_rate is 0, we repay the whole debt immediately.
         # TODO: Limit repayments in case where savings_rate=0
-        self.assertEqual(results[self.debt], Money(100))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            Money(100),
+            places=4)
 
     def test_savings_rate_half(self):
         """ Tests payments where `savings_rate=0.5`. """
         self.debt.savings_rate = Decimal(0.5)
         results = self.strategy({self.debt}, Money(25))
         # If savings_rate is 50%, we can double the payment:
-        self.assertEqual(results[self.debt], Money(50))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            Money(50),
+            places=4)
 
     def test_savings_rate_full(self):
         """ Tests payments where `savings_rate=1`. """
         self.debt.savings_rate = 1
         results = self.strategy({self.debt}, Money(50))
         # If savings_rate is 50%, we can double the payment:
-        self.assertEqual(results[self.debt], Money(50))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            Money(50),
+            places=4)
 
     def test_minimum_payment(self):
         """ Tests payments of less than `minimum_payment`. """
         self.debt.minimum_payment = Money(10)
         results = self.strategy({self.debt}, Money(0))
-        self.assertEqual(results[self.debt], Money(10))
+        self.assertAlmostEqual(
+            sum(results[self.debt].values()),
+            Money(10),
+            places=4)
 
 
 if __name__ == '__main__':

--- a/tests/strategy/test_debt_payment.py
+++ b/tests/strategy/test_debt_payment.py
@@ -73,38 +73,9 @@ class TestDebtPaymentStrategies(unittest.TestCase):
             for debt in debts
         )
 
-    def test_init_implicit(self):
-        """ Test __init__ with implicit (optional omitted) parameters. """
-        # Pylint gets confused by attributes added via a metaclass.
-        # pylint: disable=no-member
-        method = DebtPaymentStrategy.strategy_avalanche.strategy_key
-        strategy = DebtPaymentStrategy(method)
-        self.assertEqual(strategy.strategy, method)
-        self.assertEqual(strategy.timing, 'end')
-
-    def test_init_explicit(self):
-        """ Test __init__ with explicit parameters. """
-        method = 'Snowball'
-        timing = 'end'
-        strategy = DebtPaymentStrategy(method, timing)
-        self.assertEqual(strategy.strategy, method)
-        self.assertEqual(strategy.timing, timing)
-
-    def test_init_invalid(self):
-        """ Test __init__ with invalid parameters. """
-        # Test invalid strategies
-        with self.assertRaises(ValueError):
-            DebtPaymentStrategy(strategy='Not a strategy')
-        with self.assertRaises(TypeError):
-            DebtPaymentStrategy(strategy=1)
-        # Test invalid timing
-        with self.assertRaises(TypeError):
-            DebtPaymentStrategy(strategy="Snowball", timing={})
-
     def test_snowball_min_payment(self):
         """ Test strategy_snowball with the minimum payment only. """
-        payment = self.min_payment(
-            self.debts, self.strategy_snowball.timing)
+        payment = self.min_payment(self.debts, self.strategy_snowball.timing)
         results = self.strategy_snowball(self.debts, payment)
         for debt in self.debts:
             self.assertEqual(results[debt], debt.minimum_payment)

--- a/tests/strategy/test_gross_transaction.py
+++ b/tests/strategy/test_gross_transaction.py
@@ -5,7 +5,8 @@ import decimal
 from decimal import Decimal
 from forecaster import (
     Person, Money, Account, Tax,
-    LivingExpensesStrategy, LivingExpensesStrategySchedule)
+    LivingExpensesStrategy, LivingExpensesStrategySchedule,
+    Timing)
 
 
 class TestLivingExpensesStrategyMethods(unittest.TestCase):
@@ -42,6 +43,7 @@ class TestLivingExpensesStrategyMethods(unittest.TestCase):
         tax = Tax(tax_brackets={
             self.initial_year: {Money(0): Decimal(0.5)}})
         # Set up people with $4000 gross income, $2000 net income:
+        biweekly_timing = Timing(frequency="BW")
         self.person1 = Person(
             initial_year=self.initial_year,
             name="Test 1",
@@ -49,7 +51,7 @@ class TestLivingExpensesStrategyMethods(unittest.TestCase):
             retirement_date="31 December 2001",  # next year
             gross_income=Money(1000),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=biweekly_timing)
         self.person2 = Person(
             initial_year=self.initial_year,
             name="Test 2",
@@ -57,7 +59,7 @@ class TestLivingExpensesStrategyMethods(unittest.TestCase):
             retirement_date="31 December 2001",  # next year
             gross_income=Money(3000),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=biweekly_timing)
         self.people = {self.person1, self.person2}
 
         # Give person1 a $1000 account and person2 a $9,000 account:
@@ -454,7 +456,7 @@ class TestLivingExpensesStrategyScheduleMethods(unittest.TestCase):
             retirement_date="31 December 2001",  # next year
             gross_income=Money(50000),
             tax_treatment=tax,
-            payment_frequency='BW')
+            payment_timing=Timing(frequency="BW"))
         self.people = {self.person1}
 
     def test_working(self):

--- a/tests/strategy/test_transaction.py
+++ b/tests/strategy/test_transaction.py
@@ -147,20 +147,20 @@ class TestTransactionStrategyOrdered(unittest.TestCase):
         """ Test strategy_ordered with outflows to empty all account. """
         # Try withdrawing more than all of the accounts have:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) * 2
         results = self.strategy(val, self.accounts)
         # TODO: Deal with timings for outflows
         self.assertEqual(
             results[self.rrsp],
-            self.rrsp.max_outflow())
+            self.rrsp.max_outflow)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertEqual(
             results[self.taxable_account],
-            self.taxable_account.max_outflow())
+            self.taxable_account.max_outflow)
 
     def test_change_order(self):
         """ Test strategy_ordered works with changed order vars. """
@@ -227,7 +227,7 @@ class TestTransactionStrategyOrderedMult(unittest.TestCase):
         # Try to withdraw more than all accounts combined contain:
         # TODO: Deal with timings for outflows:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) * 2
         results = self.strategy(val, self.accounts)
@@ -293,7 +293,7 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         # Amount withdrawn is smaller than the balance of each account.
         # TODO: Deal with timings for outflows:
         val = Money(
-            max(account.max_outflow()
+            max(account.max_outflow
                 for account in self.accounts))
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
@@ -307,13 +307,13 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         # Now withdraw enough to exceed the TFSA's balance, plus a bit.
         # TODO: Deal with timings for outflows:
         threshold = (
-            self.tfsa.max_outflow()
+            self.tfsa.max_outflow
             / self.weights['TFSA'])
         val = Money(threshold - Money(50))
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertAlmostEqual(sum(results.values()), val, places=5)
         self.assertAlmostEqual(
             results[self.rrsp],
@@ -326,20 +326,20 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         # This will clear out the RRSP and TFSA.
         # TODO: Deal with timings for outflows:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) + Money(50)
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
         self.assertEqual(
             results[self.rrsp],
-            self.rrsp.max_outflow())
+            self.rrsp.max_outflow)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertEqual(
             results[self.taxable_account],
-            self.taxable_account.max_outflow()
+            self.taxable_account.max_outflow
             + Money(50))
 
     def test_out_all_empty(self):
@@ -347,25 +347,25 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         # Withdraw more than the accounts have:
         # TODO: Deal with timings for outflows:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) - Money(50)
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(
             results[self.rrsp],
-            self.rrsp.max_outflow())
+            self.rrsp.max_outflow)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertEqual(
             results[self.taxable_account],
-            self.taxable_account.max_outflow())
+            self.taxable_account.max_outflow)
 
     def test_in_basic(self):
         """ Test strategy_weighted with a small amount of inflows. """
         # The amount being contributed is less than the available
         # contribution room for each account
-        val = Money(min(account.max_inflow() for account in self.accounts))
+        val = Money(min(account.max_inflow for account in self.accounts))
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
         self.assertEqual(results[self.rrsp], val * self.weights['RRSP'])
@@ -380,10 +380,10 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         # TFSA but can't because of its lower contribution room) should
         # be redistributed to the other accounts proportionately to
         # their relative weights:
-        threshold = self.tfsa.max_inflow() / self.weights['TFSA']
+        threshold = self.tfsa.max_inflow / self.weights['TFSA']
         val = Money(threshold + Money(50))
         results = self.strategy_weighted(val, self.accounts)
-        self.assertEqual(results[self.tfsa], self.tfsa.max_inflow())
+        self.assertEqual(results[self.tfsa], self.tfsa.max_inflow)
         self.assertAlmostEqual(sum(results.values()), val, places=5)
         self.assertAlmostEqual(
             results[self.rrsp],
@@ -395,15 +395,15 @@ class TestTransactionStrategyWeighted(unittest.TestCase):
         """ Test strategy_weighted with inflows to fill 2 accounts. """
         # Contribute a lot of money - the rrsp and tfsa will get
         # filled and the remainder will go to the taxable account.
-        threshold = max(self.rrsp.max_inflow() / self.weights['RRSP'],
-                        self.tfsa.max_inflow() / self.weights['TFSA'])
+        threshold = max(self.rrsp.max_inflow / self.weights['RRSP'],
+                        self.tfsa.max_inflow / self.weights['TFSA'])
         val = threshold + Money(50)
         results = self.strategy_weighted(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
-        self.assertEqual(results[self.rrsp], self.rrsp.max_inflow())
-        self.assertEqual(results[self.tfsa], self.tfsa.max_inflow())
+        self.assertEqual(results[self.rrsp], self.rrsp.max_inflow)
+        self.assertEqual(results[self.tfsa], self.tfsa.max_inflow)
         self.assertEqual(results[self.taxable_account], val -
-                         (self.rrsp.max_inflow() + self.tfsa.max_inflow()))
+                         (self.rrsp.max_inflow + self.tfsa.max_inflow))
 
 
 class TestTransactionStrategyWeightedMult(unittest.TestCase):
@@ -449,7 +449,7 @@ class TestTransactionStrategyWeightedMult(unittest.TestCase):
         # Amount withdrawn is less than the balance of each account.
         # TODO: Deal with timings for outflows:
         val = Money(
-            max(account.max_outflow()
+            max(account.max_outflow
                 for account in self.accounts))
         results = self.strategy(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
@@ -471,14 +471,14 @@ class TestTransactionStrategyWeightedMult(unittest.TestCase):
         # TFSA, in this case, as it has the smallest balance):
         # TODO: Deal with timings for outflows:
         threshold = (
-            self.tfsa.max_outflow()
+            self.tfsa.max_outflow
             / self.weights['TFSA'])
         val = Money(threshold - Money(50))
         results = self.strategy(val, self.accounts)
         self.assertAlmostEqual(sum(results.values()), val, places=5)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         # The excess (i.e. the amount that would ordinarily be
         # contributed to the TFSA but can't due to contribution room
         # limits) should also be split between RRSPs and the TFSA
@@ -496,23 +496,23 @@ class TestTransactionStrategyWeightedMult(unittest.TestCase):
         # has a much larger balance and roughly similar weight:
         # TODO: Deal with timings for outflows:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) + Money(50)
         results = self.strategy(val, self.accounts)
         self.assertEqual(sum(results.values()), val)
         self.assertEqual(
             results[self.rrsp],
-            self.rrsp.max_outflow())
+            self.rrsp.max_outflow)
         self.assertEqual(
             results[self.rrsp2],
-            self.rrsp2.max_outflow())
+            self.rrsp2.max_outflow)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertEqual(
             results[self.taxable_account],
-            self.taxable_account.max_outflow()
+            self.taxable_account.max_outflow
             + Money(50))
 
     def test_out_empty_all(self):
@@ -520,19 +520,19 @@ class TestTransactionStrategyWeightedMult(unittest.TestCase):
         # Try withdrawing more than the accounts have
         # TODO: Deal with timings for outflows:
         val = sum(
-            account.max_outflow()
+            account.max_outflow
             for account in self.accounts
         ) - Money(50)
         results = self.strategy(val, self.accounts)
         self.assertEqual(
             results[self.rrsp],
-            self.rrsp.max_outflow())
+            self.rrsp.max_outflow)
         self.assertEqual(
             results[self.tfsa],
-            self.tfsa.max_outflow())
+            self.tfsa.max_outflow)
         self.assertEqual(
             results[self.taxable_account],
-            self.taxable_account.max_outflow())
+            self.taxable_account.max_outflow)
 
     def test_in_basic(self):
         """ Test strategy_weighted with multiple RRSPs, small inflows. """

--- a/tests/test_accounts/test_base.py
+++ b/tests/test_accounts/test_base.py
@@ -148,13 +148,12 @@ class TestAccountMethods(unittest.TestCase):
         self.assertIsInstance(account.nper, int)
         self.assertIsInstance(account.initial_year, int)
 
-    def test_init_invalid(self, *args, **kwargs):
-        """ Test Account.__init__ with invalid inputs. """
+    def test_init_invalid_balance(self, *args, **kwargs):
+        """ Test Account.__init__ with invalid balance input. """
         # Let's test invalid Decimal conversions next.
         # (BasicContext causes most Decimal-conversion errors to raise
         # exceptions. Invalid input will raise InvalidOperation)
         decimal.setcontext(decimal.BasicContext)
-        balance = 0
 
         # Test with values not convertible to Decimal
         with self.assertRaises(decimal.InvalidOperation):
@@ -165,19 +164,24 @@ class TestAccountMethods(unittest.TestCase):
             if account.balance == Money("NaN"):
                 raise decimal.InvalidOperation()
 
+    def test_init_invalid_rate(self, *args, **kwargs):
+        """ Test Account.__init__ with invalid rate input. """
+        decimal.setcontext(decimal.BasicContext)
         with self.assertRaises(decimal.InvalidOperation):
             account = self.AccountType(
                 self.owner, *args,
-                balance=balance, rate="invalid input", **kwargs)
-            # `rate` can be Decimal-typed or a callable
+                balance=0, rate="invalid input", **kwargs)
+            # `rate` is not callable if we use non-callable input
             # pylint: disable=comparison-with-callable
             if account.rate == Decimal("NaN"):
                 raise decimal.InvalidOperation()
             # pylint: enable=comparison-with-callable
 
+    def test_init_invalid_owner(self, *args, **kwargs):
+        """ Test Account.__init__ with invalid rate input. """
         # Finally, test passing an invalid owner:
         with self.assertRaises(TypeError):
-            account = self.AccountType(
+            _ = self.AccountType(
                 "invalid owner", *args, **kwargs)
 
     def test_add_trans_in_range(self):
@@ -373,8 +377,8 @@ class TestAccountMethods(unittest.TestCase):
         # TODO: Test add_transactions again after performing next_year
         # (do this recursively?)
 
-    def test_max_outflow(self, *args, **kwargs):
-        """ Test Account.max_outflow """
+    def test_max_outflow_constant(self, *args, **kwargs):
+        """ Test Account.max_outflow with constant-balance account """
         # Simple scenario: $100 in a no-growth account with no
         # transactions. Should return $100 for any point in time.
         account = self.AccountType(
@@ -383,12 +387,16 @@ class TestAccountMethods(unittest.TestCase):
         self.assertEqual(account.max_outflow(0.5), Money(-100))
         self.assertEqual(account.max_outflow('end'), Money(-100))
 
+    def test_max_outflow_negative(self, *args, **kwargs):
+        """ Test Account.max_outflow with negative-balance account. """
         # Try with negative balance - should return $0
         account = self.AccountType(
             self.owner, *args, balance=-100, rate=1, nper=1, **kwargs)
         self.assertEqual(account.max_outflow('start'), Money(0))
         self.assertEqual(account.max_outflow('end'), Money(0))
 
+    def test_max_outflow_simple(self, *args, **kwargs):
+        """ Test Account.max_outflow with simple growth, no transactions """
         # $100 in account that grows to $200 in one compounding period.
         # No transactions.
         # NOTE: Account balances mid-compounding-period are not
@@ -400,6 +408,8 @@ class TestAccountMethods(unittest.TestCase):
         # self.assertEqual(account.max_outflow(0.5), Money(-150))
         self.assertEqual(account.max_outflow('end'), Money(-200))
 
+    def test_max_outflow_simple_trans(self, *args, **kwargs):
+        """ Test Account.max_outflow with simple growth and transactions """
         # $100 in account that grows linearly by 100%. Add $100
         # transactions at the start and end of the year.
         # NOTE: Behaviour of transactions between compounding
@@ -415,6 +425,8 @@ class TestAccountMethods(unittest.TestCase):
         # self.assertEqual(account.max_outflow(0.75), Money(-350))
         self.assertEqual(account.max_outflow('end'), Money(-500))
 
+    def test_max_outflow_neg_to_pos(self, *args, **kwargs):
+        """ Test Account.max_outflow going from neg. to pos. balance """
         # Try with a negative starting balance and a positive ending
         # balance. With -$100 start and 200% interest compounding at
         # t=0.5, balance should be -$200 at t=0.5. Add $200 transaction
@@ -430,6 +442,8 @@ class TestAccountMethods(unittest.TestCase):
         self.assertEqual(account.max_outflow(0.5), Money(0))
         self.assertEqual(account.max_outflow('end'), Money(-100))
 
+    def test_max_outflow_compound_disc(self, *args, **kwargs):
+        """ Test Account.max_outflow with discrete compounding """
         # Test compounding. First: discrete compounding, once at the
         # halfway point. Add a $100 transaction at when=0.5 just to be
         # sure.
@@ -442,6 +456,8 @@ class TestAccountMethods(unittest.TestCase):
         # self.assertEqual(account.max_outflow(0.75), Money(-312.50))
         self.assertEqual(account.max_outflow('end'), Money(-375))
 
+    def test_max_outflow_compound_cont(self, *args, **kwargs):
+        """ Test Account.max_outflow with continuous compounding. """
         # Now to test continuous compounding. Add a $100 transaction at
         # when=0.5 just to be sure.
         account = self.AccountType(
@@ -459,41 +475,58 @@ class TestAccountMethods(unittest.TestCase):
                                -Money(100 * math.e +
                                       100 * math.e ** 0.5), 5)
 
-    def test_max_inflow(self, *args, **kwargs):
-        """ Test Account.max_inflow """
+    def test_max_inflow_pos(self, *args, **kwargs):
+        """ Test Account.max_inflow with positive balance """
         # This method should always return Money('Infinity')
         account = self.AccountType(
             self.owner, *args, balance=100, **kwargs)
         self.assertEqual(account.max_inflow(), Money('Infinity'))
 
+    def test_max_inflow_neg(self, *args, **kwargs):
+        """ Test Account.max_inflow with negative balance """
         account = self.AccountType(
             self.owner, *args, balance=-100, **kwargs)
         self.assertEqual(account.max_inflow(), Money('Infinity'))
 
-    def test_min_outflow(self, *args, **kwargs):
-        """ Test Account.min_outflow """
+    def test_min_outflow_pos(self, *args, **kwargs):
+        """ Test Account.min_outflow with positive balance """
         # This method should always return $0
         account = self.AccountType(
             self.owner, *args, balance=100, **kwargs)
         self.assertEqual(account.min_outflow(), Money(0))
 
+    def test_min_outflow_neg(self, *args, **kwargs):
+        """ Test Account.min_outflow with negative balance """
         account = self.AccountType(
             self.owner, *args, balance=-100, **kwargs)
         self.assertEqual(account.min_outflow(), Money(0))
 
-    def test_min_inflow(self, *args, **kwargs):
-        """ Test Account.min_inflow """
+    def test_min_inflow_pos(self, *args, **kwargs):
+        """ Test Account.min_inflow with positive balance """
         # This method should always return $0
         account = self.AccountType(
             self.owner, *args, balance=100, **kwargs)
         self.assertEqual(account.min_inflow(), Money(0))
 
+    def test_min_inflow_neg(self, *args, **kwargs):
+        """ Test Account.min_inflow with negative balance """
         account = self.AccountType(
             self.owner, *args, balance=-100, **kwargs)
         self.assertEqual(account.min_inflow(), Money(0))
 
-    def test_taxable_income(self, *args, **kwargs):
-        """ Test Account.taxable_income """
+    def test_max_outflows(self, *args, **kwargs):
+        """ Test Account.max_outflows. """
+        account = self.AccountType(
+            self.owner, *args, balance=100, rate=1, nper=1, **kwargs)
+        # This is taken straight from the docstring example:
+        result = account.max_outflows({0: 1, 1: 1})
+        target = {0: Money(-200)/3, 1: Money(-200)/3}
+        self.assertEqual(result.keys(), target.keys())
+        for timing in result:
+            self.assertAlmostEqual(result[timing], target[timing], places=2)
+
+    def test_taxable_income_gain(self, *args, **kwargs):
+        """ Test Account.taxable_income with gains in account """
         # This method should return the growth in the account, which is
         # $200 at the start of the period. (The $100 withdrawal at the
         # end of the period doesn't affect taxable income.)
@@ -503,6 +536,8 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.taxable_income, Money(200))
 
+    def test_taxable_income_loss(self, *args, **kwargs):
+        """ Test Account.taxable_income with losses in account """
         # Losses are not taxable:
         account = self.AccountType(
             self.owner, *args, balance=-100, rate=1.0, **kwargs)
@@ -510,8 +545,8 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.taxable_income, Money(0))
 
-    def test_tax_withheld(self, *args, **kwargs):
-        """ Test Account.tax_withheld """
+    def test_tax_withheld_pos(self, *args, **kwargs):
+        """ Test Account.tax_withheld with positive balance. """
         # This method should always return $0
         account = self.AccountType(
             self.owner, *args, balance=100, rate=1.0, **kwargs)
@@ -519,14 +554,16 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.tax_withheld, Money(0))
 
+    def test_tax_withheld_neg(self, *args, **kwargs):
+        """ Test Account.tax_withheld with negative balance. """
         account = self.AccountType(
             self.owner, *args, balance=-100, rate=1.0, **kwargs)
         account.add_transaction(100, when='start')
         account.add_transaction(-100, when='end')
         self.assertEqual(account.tax_withheld, Money(0))
 
-    def test_tax_credit(self, *args, **kwargs):
-        """ Test Account.tax_credit """
+    def test_tax_credit_pos(self, *args, **kwargs):
+        """ Test Account.tax_credit with positive balance """
         # This method should always return $0, regardless of balance,
         # inflows, or outflows
         account = self.AccountType(
@@ -535,6 +572,8 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.tax_credit, Money(0))
 
+    def test_tax_credit_neg(self, *args, **kwargs):
+        """ Test Account.tax_credit with negative balance """
         # Test with negative balance
         account = self.AccountType(
             self.owner, *args, balance=-100, rate=1.0, **kwargs)
@@ -542,8 +581,8 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.tax_credit, Money(0))
 
-    def test_tax_deduction(self, *args, **kwargs):
-        """ Test Account.tax_deduction """
+    def test_tax_deduction_pos(self, *args, **kwargs):
+        """ Test Account.tax_deduction with positive balance """
         # This method should always return $0, regardless of balance,
         # inflows, or outflows
         account = self.AccountType(
@@ -552,6 +591,8 @@ class TestAccountMethods(unittest.TestCase):
         account.add_transaction(-100, when='end')
         self.assertEqual(account.tax_deduction, Money(0))
 
+    def test_tax_deduction_neg(self, *args, **kwargs):
+        """ Test Account.tax_deduction with negative balance """
         # Test with negative balance
         account = self.AccountType(
             self.owner, *args, balance=-100, rate=1.0, **kwargs)

--- a/tests/test_accounts/test_contribution_limited.py
+++ b/tests/test_accounts/test_contribution_limited.py
@@ -75,20 +75,32 @@ class TestContributionLimitAccountMethods(TestAccountMethods):
         self.assertEqual(account.contribution_room,
                          self.contribution_room)
 
-    def test_max_inflow_pos(self, *args, **kwargs):
-        """ Test max_inflow with positive balance. """
+    def test_max_inflows_pos(self, *args, **kwargs):
+        """ Test max_inflows with positive balance """
+        # Need to pass the superclass a suitable `contribution_room`
+        super().test_max_outflows_negative(
+            contribution_room=self.contribution_room)
+
+    def test_max_inflows_neg(self, *args, **kwargs):
+        """ Test max_inflows with negative balance """
+        # Need to pass the superclass a suitable `contribution_room`
+        super().test_max_outflows_negative(
+            contribution_room=self.contribution_room)
+
+    def test_max_inflow(self, *args, **kwargs):
+        """ Test max_inflow matches contribution room. """
         # Init an account with standard parameters, confirm that
         # max_inflow corresponds to contribution_room.
         account = self.AccountType(
             self.owner, *args,
             contribution_room=self.contribution_room, **kwargs)
-        self.assertEqual(account.max_inflow(), self.contribution_room)
+        self.assertEqual(account.max_inflow, self.contribution_room)
 
-    def test_max_inflow_neg(self, *args, **kwargs):
-        """ Test max_inflow with negative balance. """
-        # Account balance is irrelevant to this type of account.
-        # Should yield same result as test_max_inflow_pos
-        self.test_max_inflow_pos(*args, **kwargs)
+    def test_max_outflows_negative(self, *args, **kwargs):
+        """ Test max_outflows with negative-balance account. """
+        # Need to pass the superclass a suitable `contribution_room`
+        super().test_max_outflows_negative(
+            contribution_room=self.contribution_room)
 
     def test_contribution_room_basic(self, *args, **kwargs):
         """ Test sharing of contribution room between accounts. """

--- a/tests/test_accounts/test_contribution_limited.py
+++ b/tests/test_accounts/test_contribution_limited.py
@@ -50,18 +50,17 @@ class TestContributionLimitAccountMethods(TestAccountMethods):
             self.owner, *args, contribution_room=Money(100), **kwargs)
         self.assertEqual(account.contribution_room, Money(100))
 
-    def test_init_invalid(self, *args, **kwargs):
-        """ Test ContributionLimitAccount.__init__ with invalid inputs. """
-        super().test_init_invalid(
-            *args, contribution_room=self.contribution_room, **kwargs)
-
+    def test_init_invalid_contriburor(self, *args, **kwargs):
+        """ Test invalid contributor at init. """
         # Test invalid `person` input
         with self.assertRaises(TypeError):
             self.AccountType(
                 self.owner, contributor='invalid person',
                 *args, **kwargs)
 
-        # Finally, test a non-Money-convertible contribution_room:
+    def test_init_invalid_room(self, *args, **kwargs):
+        """ Test invalid contribution_room at init. """
+        # Test a non-Money-convertible contribution_room:
         with self.assertRaises(decimal.InvalidOperation):
             self.AccountType(
                 self.owner, *args,
@@ -76,14 +75,20 @@ class TestContributionLimitAccountMethods(TestAccountMethods):
         self.assertEqual(account.contribution_room,
                          self.contribution_room)
 
-    def test_max_inflow(self, *args, **kwargs):
-        """ Test ContributionLimitAccount.max_inflow. """
+    def test_max_inflow_pos(self, *args, **kwargs):
+        """ Test max_inflow with positive balance. """
         # Init an account with standard parameters, confirm that
         # max_inflow corresponds to contribution_room.
         account = self.AccountType(
             self.owner, *args,
             contribution_room=self.contribution_room, **kwargs)
         self.assertEqual(account.max_inflow(), self.contribution_room)
+
+    def test_max_inflow_neg(self, *args, **kwargs):
+        """ Test max_inflow with negative balance. """
+        # Account balance is irrelevant to this type of account.
+        # Should yield same result as test_max_inflow_pos
+        self.test_max_inflow_pos(*args, **kwargs)
 
     def test_contribution_room_basic(self, *args, **kwargs):
         """ Test sharing of contribution room between accounts. """

--- a/tests/test_accounts/test_contribution_limited.py
+++ b/tests/test_accounts/test_contribution_limited.py
@@ -94,7 +94,7 @@ class TestContributionLimitAccountMethods(TestAccountMethods):
         account = self.AccountType(
             self.owner, *args,
             contribution_room=self.contribution_room, **kwargs)
-        self.assertEqual(account.max_inflow, self.contribution_room)
+        self.assertEqual(account.max_inflow_limit, self.contribution_room)
 
     def test_max_outflows_negative(self, *args, **kwargs):
         """ Test max_outflows with negative-balance account. """

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,8 +1,12 @@
 ''' Runs all unit tests for the `Forecaster` package '''
 
 import unittest
+import warnings
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().discover('.', pattern='test_*.py')
+    # Money throws a lot of deprecation warnings. Ignore these when
+    # running a global test.
+    warnings.simplefilter("ignore", DeprecationWarning)
+
     unittest.TextTestRunner().run(SUITE)
-    # unittest.main()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -4,5 +4,5 @@ import unittest
 
 if __name__ == '__main__':
     SUITE = unittest.TestLoader().discover('.', pattern='test_*.py')
-    unittest.TextTestRunner(verbosity=2).run(SUITE)
+    unittest.TextTestRunner().run(SUITE)
     # unittest.main()

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -50,12 +50,10 @@ class TestForecaster(unittest.TestCase):
             inflation_adjust=self.scenario.inflation_adjust)
         self.contribution_strategy = AccountTransactionStrategy(
             strategy=self.settings.contribution_strategy,
-            weights=self.settings.contribution_weights,
-            timing=self.settings.contribution_timing)
+            weights=self.settings.contribution_weights)
         self.withdrawal_strategy = AccountTransactionStrategy(
             strategy=self.settings.withdrawal_strategy,
-            weights=self.settings.withdrawal_weights,
-            timing=self.settings.withdrawal_timing)
+            weights=self.settings.withdrawal_weights)
         self.allocation_strategy = AllocationStrategy(
             strategy=self.settings.allocation_strategy,
             min_equity=self.settings.allocation_min_equity,
@@ -67,8 +65,7 @@ class TestForecaster(unittest.TestCase):
             adjust_for_retirement_plan=(
                 self.settings.allocation_adjust_retirement))
         self.debt_payment_strategy = DebtPaymentStrategy(
-            strategy=self.settings.debt_payment_strategy,
-            timing=self.settings.debt_payment_timing)
+            strategy=self.settings.debt_payment_strategy)
         self.tax_treatment = Tax(
             tax_brackets=self.settings.tax_brackets,
             personal_deduction=self.settings.tax_personal_deduction,


### PR DESCRIPTION
This PR adds the `Timing` class, replaces `when` and `frequency` attributes of `Account` and `Person` with a attributes that expect a `Timing`-like object, and adds various timing-aware methods to `Account`, `Person`, and `Strategy` (along with corresponding changes to `SubForecast` subclasses). This closes #62.

Most code which called `Account.max_inflow` (which took a scalar `when` attribute) now calls the timing-aware `Account.max_inflows` (which takes a `Timing`-like time series input). `Account.max_inflow_limit` and similar properties are added to generalize the concept of providing upper and lower bounds on inflows and outflows.

A major compatibility-breaking change is that `AccountTransactionsStrategy.__call__` now returns a mapping from `Accounts` to dictionaries of transactions (rather than scalar `Money` values). This required changes to some `SubForecast` subclasses, including changing the expected typing of the `account_transactions` properties. This relates to #51 but does not close it since `AccountTransactionStrategy.__call__` still ingests a scalar arg instead of a `Timing`-like object and `DebtPaymentStrategy` is entirely unchanged.