### PR TITLE
Adding support for tax carryovers

### DIFF
--- a/forecaster/canada/constants.py
+++ b/forecaster/canada/constants.py
@@ -134,3 +134,10 @@ TAX_SPOUSAL_AMOUNT = {
     'Federal': {2017: Decimal(11635)},
     'BC': {2017: Decimal(9614)}
 }
+
+# Deadline to file is April 30th (120/365 ~= 0.328), and the refund
+# is paid shortly thereafter. Truncate this to 0.3 for simplicity.
+TAX_REFUND_TIMING = Decimal('0.3')
+# Deadline to pay any amounts owing is April 30th (120/365).
+# Truncate this to 0.3 for simplicity.
+TAX_PAYMENT_TIMING = Decimal('0.3')

--- a/forecaster/canada/tax.py
+++ b/forecaster/canada/tax.py
@@ -11,8 +11,7 @@ class TaxCanadaJurisdiction(Tax):
     """ Federal or provincial tax treatment (Canada). """
 
     def __init__(
-            self, inflation_adjustments, jurisdiction='Federal',
-            payment_timing='start'):
+            self, inflation_adjustments, jurisdiction='Federal'):
         super().__init__(
             tax_brackets=constants.TAX_BRACKETS[jurisdiction],
             personal_deduction=constants.TAX_PERSONAL_DEDUCTION[
@@ -20,7 +19,8 @@ class TaxCanadaJurisdiction(Tax):
             ],
             credit_rate=constants.TAX_CREDIT_RATE[jurisdiction],
             inflation_adjust=inflation_adjustments,
-            payment_timing=payment_timing)
+            refund_timing=constants.TAX_REFUND_TIMING,
+            payment_timing=constants.TAX_PAYMENT_TIMING)
 
         self.jurisdiction = jurisdiction
 
@@ -159,7 +159,7 @@ class TaxCanada(object):
     """
 
     def __init__(
-            self, inflation_adjust, province='BC', payment_timing='start'):
+            self, inflation_adjust, province='BC'):
         """ Initializes TaxCanada.
 
         Args:
@@ -175,20 +175,30 @@ class TaxCanada(object):
                 payments. See `Tax` documentation for more information.
         """
         self.federal_tax = TaxCanadaJurisdiction(
-            inflation_adjust, payment_timing=payment_timing)
+            inflation_adjust)
         self.provincial_tax = TaxCanadaJurisdiction(
-            inflation_adjust, province, payment_timing=payment_timing)
+            inflation_adjust, province)
         self.province = province
 
     @property
     def payment_timing(self):
-        """ Timing for refunds and payments. """
+        """ Timing for payments. """
         return self.federal_tax.payment_timing
 
     @payment_timing.setter
     def payment_timing(self, val):
         """ Sets `payment_timing`. """
         self.federal_tax.payment_timing = val
+
+    @property
+    def refund_timing(self):
+        """ Timing for refunds. """
+        return self.federal_tax.refund_timing
+
+    @refund_timing.setter
+    def refund_timing(self, val):
+        """ Sets `refund_timing`. """
+        self.federal_tax.refund_timing = val
 
     # Marginal rate information is helpful for client code, so implement
     # it here based on fed. and prov. tax brackets:

--- a/forecaster/forecast/tax.py
+++ b/forecaster/forecast/tax.py
@@ -26,6 +26,11 @@ class TaxForecast(SubForecast):
             positive) or paid (if negative) in next year's tax season
             due to excess/insufficient withholding taxes during this
             year.
+        tax_refund_timing (Timing): The timing with which tax refunds
+            are received.
+        tax_owing_timing (Timing): The timing with which tax payments
+            must be made, if there is an amount owing for the year in
+            excess of the amount withheld.
     """
 
     def __init__(
@@ -36,12 +41,6 @@ class TaxForecast(SubForecast):
         # Store input values
         self.people = people
         self.tax_treatment = tax_treatment
-
-    # TODO: Add __call__ method to apply tax_adjustment?
-    # One option would be to clear `available` and add
-    # appropriately-timed inflows/outflows for rebates/amounts owing,
-    # on the assumption that this is the last subforecast to be called.
-    # At present that doesn't seem necessary.
 
     @recorded_property_cached
     def tax_withheld(self):
@@ -67,3 +66,13 @@ class TaxForecast(SubForecast):
         Negative values are amounts owing, positive are refunds.
         """
         return self.tax_withheld - self.tax_owing
+
+    @property
+    def tax_refund_timing(self):
+        """ Timing of refunds from the tax authority. """
+        return self.tax_treatment.refund_timing
+
+    @property
+    def tax_payment_timing(self):
+        """ Timing of payments to the tax authority for amounts owing. """
+        return self.tax_treatment.payment_timing

--- a/forecaster/utility.py
+++ b/forecaster/utility.py
@@ -80,10 +80,41 @@ class Timing(dict):
 
             # Build out multiple timings based on scalar inputs.
             # Each transaction has equal weight:
-            weight = 1 / frequency
+            weight = 1 / Decimal(frequency)
             # Build the dict:
             for time in range(frequency):
                 self[(time + when) / frequency] = weight
+
+    def time_series(self, scalar):
+        """ Scales `scalar` into portions proportionate to this timing.
+
+        This method essentially performs scalar multiplication, where
+        `scalar` is the scalar value and `self` is the (normed) vector.
+        The result is a time-series that has the same proportions as
+        `self` and sums to `scalar`.
+
+        Args:
+            scalar (Any): Any scalar value (not necessarily `Number`;
+                may be `Money`, for instance). Any type that supports
+                multiplication against the values of `Timing` may be
+                used.
+
+        Returns:
+            dict[Decimal, Any]: A time-series of values with the same
+                proportions as this timing object, with values of the
+                same type as `scalar` and which sum to `other`.
+
+        Raises:
+            ValueError: `scalar` does not support multiplication by the
+            values of this timing object.
+        """
+        # `Timing` is not necessarily normalized, so do that manually:
+        normalization = sum(self.values())
+        # Split up `scalar` into smaller amounts for each key in `self`
+        # proportionate to the (normalized) values of `self`.
+        return {
+            timing: scalar * (weight / normalization)
+            for timing, weight in self.items()}
 
 def _convert_dict(when):
     """ Converts `dict` input to `Timing`-style `when: weight` pairs.

--- a/tests/canada/test_tax.py
+++ b/tests/canada/test_tax.py
@@ -114,6 +114,12 @@ class TestTaxCanada(unittest.TestCase):
                 tax.federal_tax.credit_rate(year),
                 constants.TAX_CREDIT_RATE['Federal'][year])
         self.assertTrue(callable(tax.federal_tax.inflation_adjust))
+        # Test that the default timings for CRA refunds/payments have
+        # been set:
+        self.assertEqual(
+            set(tax.payment_timing), {constants.TAX_PAYMENT_TIMING})
+        self.assertEqual(
+            set(tax.refund_timing), {constants.TAX_REFUND_TIMING})
 
     def test_init_provincial(self):
         """ Test TaxCanada.__init__ for provincial jurisdiction. """

--- a/tests/test_tax.py
+++ b/tests/test_tax.py
@@ -386,6 +386,17 @@ class TestTax(unittest.TestCase):
             single_tax * 2,
             double_tax)
 
+    def test_payment_timing(self):
+        """ Tests `payment_timing` property. """
+        # `payment_timing` should have exactly one timing: 0
+        self.tax.payment_timing = 'start'
+        self.assertEqual(set(self.tax.payment_timing), {0})
+
+    def test_refund_timing(self):
+        """ Tests `refund_timing` property. """
+        # `refund_timing` should have exactly one timing: 0
+        self.tax.refund_timing = 'start'
+        self.assertEqual(set(self.tax.refund_timing), {0})
 
 if __name__ == '__main__':
     unittest.TextTestRunner().run(

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -58,6 +58,10 @@ class TestTiming(unittest.TestCase):
         target = Timing({0.25: 10000, 0.75: 10000})
         self.assertEqual(timing, target)
 
+    def test_time_series(self):
+        """ TODO """
+        pass
+
 class TestFreeMethods(unittest.TestCase):
     """ A test case for the free methods in the utility module. """
 


### PR DESCRIPTION
These commits allow for tax refunds and payments to be issued at different times and for `Forecast` to roll them over to the next year at the appropriate time. It also adds a convenience method to `Timing` for yielding a time-series (e.g. a transaction dict) from a scalar value.

Closes #31. Completes milestone 0.1.