### PR TITLE
Adding TaxMulti

### DIFF
--- a/forecaster/canada/tax.py
+++ b/forecaster/canada/tax.py
@@ -24,7 +24,7 @@ class TaxCanadaJurisdiction(Tax):
 
         self.jurisdiction = jurisdiction
 
-    def credits(self, person, year, deduction=None):
+    def credit(self, person, year, deduction=None):
         """ Finds tax credit available for each taxpayer.
 
         Args:
@@ -41,7 +41,7 @@ class TaxCanadaJurisdiction(Tax):
         """
         # Get basic credits (i.e. those tied to accounts) from the
         # superclass method:
-        _credits = super().credits(person, year, deduction)
+        _credits = super().credit(person, year, deduction)
 
         # Apply the pension income tax credit for each person:
         _credits += self._pension_income_credit(person, year)

--- a/forecaster/tax.py
+++ b/forecaster/tax.py
@@ -461,10 +461,11 @@ class Tax(object):
         if person.spouse is not None and person.spouse in people:
             # Process taxes for the couple and recurse on the remaining
             # people.
-            return self.tax_spouses(
-                {person, person.spouse}, year, deduction, credit)
-            + self.tax_people(
-                people - {person, person.spouse}, year, deduction, credit)
+            return (
+                self.tax_spouses(
+                    {person, person.spouse}, year, deduction, credit)
+                + self.tax_people(
+                    people - {person, person.spouse}, year, deduction, credit))
         # Otherwise, process this person as a single individual and
         # recurse on the remaining folks:
         else:

--- a/tests/canada/test_tax.py
+++ b/tests/canada/test_tax.py
@@ -205,15 +205,18 @@ class TestTaxCanada(unittest.TestCase):
         spousal_tax = self.tax.federal_tax(
             {self.person1, self.person2}, self.initial_year)
 
+        # Tax should be reduced (relative to baseline) by the shortfall
+        # of person2's income (relative to the spousal amount, after
+        # applying deductions), scaled down by the credit rate.
+        # That is, for every dollar that person2 earns _under_ the
+        # spousal amount, tax is reduced by (e.g.) 15 cents (assuming
+        # a credit rate of 15%)
         target = baseline_tax - (
-            shortfall * self.tax.federal_tax.credit_rate(
-                self.initial_year))
+            shortfall * self.tax.federal_tax.credit_rate(self.initial_year))
 
         # The different between these scenarios should be equal to
         # the amount of the spousal tax credit:
-        self.assertEqual(
-            spousal_tax,
-            target)
+        self.assertEqual(spousal_tax, target)
 
     def test_pension_tax_credit(self):
         """ Test pension tax credit behaviour. """

--- a/tests/canada/test_tax.py
+++ b/tests/canada/test_tax.py
@@ -19,8 +19,7 @@ class TestTaxCanada(unittest.TestCase):
         year_range = range(cls.initial_year, cls.initial_year + 100)
         cls.inflation_adjustments = {
             year: 1 + (year - cls.initial_year) / growth_factor
-            for year in year_range
-        }
+            for year in year_range}
 
         # Build some brackets with nice round numbers:
         constants.TAX_BRACKETS = {
@@ -28,29 +27,21 @@ class TestTaxCanada(unittest.TestCase):
                 cls.initial_year: {
                     Money(0): Decimal('0.1'),
                     Money('100'): Decimal('0.2'),
-                    Money('10000'): Decimal('0.3')
-                }
-            },
+                    Money('10000'): Decimal('0.3')}},
             'BC': {
                 cls.initial_year: {
                     Money(0): Decimal('0.25'),
                     Money('1000'): Decimal('0.5'),
-                    Money('100000'): Decimal('0.75')
-                }
-            }
-        }
+                    Money('100000'): Decimal('0.75')}}}
         constants.TAX_PERSONAL_DEDUCTION = {
             'Federal': {cls.initial_year: Money('100')},
-            'BC': {cls.initial_year: Money('1000')}
-        }
+            'BC': {cls.initial_year: Money('1000')}}
         constants.TAX_CREDIT_RATE = {
             'Federal': {cls.initial_year: Decimal('0.1')},
-            'BC': {cls.initial_year: Decimal('0.25')}
-        }
+            'BC': {cls.initial_year: Decimal('0.25')}}
         constants.TAX_PENSION_CREDIT = {
             'Federal': {cls.initial_year: Money('100')},
-            'BC': {cls.initial_year: Decimal('1000')}
-        }
+            'BC': {cls.initial_year: Decimal('1000')}}
         # It's convenient (and accurate!) to use the same values
         # for the spousal amount and the personal deduction:
         constants.TAX_SPOUSAL_AMOUNT = constants.TAX_PERSONAL_DEDUCTION
@@ -104,9 +95,7 @@ class TestTaxCanada(unittest.TestCase):
                 {
                     Money(bracket): value
                     for bracket, value in
-                    constants.TAX_BRACKETS['Federal'][year].items()
-                }
-            )
+                    constants.TAX_BRACKETS['Federal'][year].items()})
             self.assertEqual(
                 tax.federal_tax.personal_deduction(year),
                 constants.TAX_PERSONAL_DEDUCTION['Federal'][year])
@@ -130,9 +119,7 @@ class TestTaxCanada(unittest.TestCase):
                 {
                     Money(bracket): value
                     for bracket, value in
-                    constants.TAX_BRACKETS[self.province][year].items()
-                }
-            )
+                    constants.TAX_BRACKETS[self.province][year].items()})
             self.assertEqual(
                 tax.provincial_tax.personal_deduction(year),
                 constants.TAX_PERSONAL_DEDUCTION[self.province][year])
@@ -150,9 +137,7 @@ class TestTaxCanada(unittest.TestCase):
                 {
                     Money(bracket): value
                     for bracket, value in
-                    constants.TAX_BRACKETS[self.province][year].items()
-                }
-            )
+                    constants.TAX_BRACKETS[self.province][year].items()})
             self.assertEqual(
                 tax.provincial_tax.personal_deduction(year),
                 constants.TAX_PERSONAL_DEDUCTION[self.province][year])
@@ -167,24 +152,21 @@ class TestTaxCanada(unittest.TestCase):
         self.assertEqual(
             self.tax(taxable_income, self.initial_year),
             self.tax.federal_tax(taxable_income, self.initial_year) +
-            self.tax.provincial_tax(taxable_income, self.initial_year)
-        )
+            self.tax.provincial_tax(taxable_income, self.initial_year))
 
     def test_call_person(self):
         """ Test TaxCanada.__call__ on one Person input """
         self.assertEqual(
             self.tax(self.person1, self.initial_year),
             self.tax.federal_tax(self.person1, self.initial_year) +
-            self.tax.provincial_tax(self.person1, self.initial_year)
-        )
+            self.tax.provincial_tax(self.person1, self.initial_year))
 
     def test_call_person_set(self):
         """ Test TaxCanada.__call__ on a one-Person set input """
         # Should get the same result as for a setless Person:
         self.assertEqual(
             self.tax({self.person1}, self.initial_year),
-            self.tax(self.person1, self.initial_year)
-        )
+            self.tax(self.person1, self.initial_year))
 
     def test_call_people(self):
         """ Test TaxCanada.__call__ on a set of multiple people. """
@@ -193,12 +175,9 @@ class TestTaxCanada(unittest.TestCase):
         self.assertEqual(
             self.tax({self.person1, self.person2}, self.initial_year),
             self.tax.federal_tax(
-                {self.person1, self.person2}, self.initial_year
-            ) +
-            self.tax.provincial_tax(
-                {self.person1, self.person2}, self.initial_year
-            )
-        )
+                {self.person1, self.person2}, self.initial_year)
+            + self.tax.provincial_tax(
+                {self.person1, self.person2}, self.initial_year))
 
     def test_spousal_tax_credit(self):
         """ Test spousal tax credit behaviour. """
@@ -207,38 +186,34 @@ class TestTaxCanada(unittest.TestCase):
         spousal_amount = (
             constants.TAX_SPOUSAL_AMOUNT['Federal'][self.initial_year])
         shortfall = spousal_amount / 2
-        deductions = self.tax.federal_tax.deductions(
+        deduction = self.tax.federal_tax.deduction(
             self.person2, self.initial_year)
-        self.person2.gross_income = deductions + spousal_amount - shortfall
+        self.person2.gross_income = deduction + spousal_amount - shortfall
 
-        # Ensure that there are is no taxable income for person2
-        # beyond the above (to stay under spousal amount):
+        # Ensure that there is no taxable income for person2 beyond the
+        # above (to stay under spousal amount):
         self.taxable_account2.owner = self.person1
 
         # Get a tax treatment baseline for unrelated people:
         baseline_tax = self.tax.federal_tax(
-            {self.person1, self.person2}, self.initial_year
-        )
+            {self.person1, self.person2}, self.initial_year)
 
         # Wed the two people in holy matrimony:
         self.person1.spouse = self.person2
 
         # Now determine total tax liability federally:
         spousal_tax = self.tax.federal_tax(
-            {self.person1, self.person2}, self.initial_year
-        )
+            {self.person1, self.person2}, self.initial_year)
 
         target = baseline_tax - (
             shortfall * self.tax.federal_tax.credit_rate(
-                self.initial_year)
-        )
+                self.initial_year))
 
         # The different between these scenarios should be equal to
         # the amount of the spousal tax credit:
         self.assertEqual(
             spousal_tax,
-            target
-        )
+            target)
 
     def test_pension_tax_credit(self):
         """ Test pension tax credit behaviour. """

--- a/tests/strategy/transaction/test_node.py
+++ b/tests/strategy/transaction/test_node.py
@@ -1,3 +1,6 @@
-""" TODO """
+""" Tests for node.py """
 
-# TODO: Add tests for TransactionNode.
+# NOTE: All functionality of this module is tested indirectly by
+# `test_base.py` (via tests for TransactionTraversal).
+# For now, we aren't adding separate tests for `node.py` methods,
+# since it doesn't improve code coverage.

--- a/tests/strategy/transaction/test_util.py
+++ b/tests/strategy/transaction/test_util.py
@@ -1,3 +1,6 @@
-""" TODO """
+""" Tests for `util.py` """
 
-# TODO: Add tests for helper methods.
+# NOTE: All functionality of this module is tested indirectly by
+# `test_base.py` (via tests for TransactionTraversal).
+# For now, we aren't adding separate tests for `util.py` methods,
+# since it doesn't improve code coverage.

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -3,6 +3,7 @@
 import unittest
 import decimal
 from decimal import Decimal
+from forecaster.ledger.money import Money
 from forecaster.utility import (
     Timing, transactions_from_timing,
     nearest_year, extend_inflation_adjusted,
@@ -24,41 +25,156 @@ class TestTiming(unittest.TestCase):
     #    `Timing(1)`)
 
     def test_init_when_freq(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a single parameter, `when`. """
+        timing = Timing(0.5)
+        self.assertEqual(set(timing.keys()), {0.5})
 
     def test_init_str_freq(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a single str parameter, `frequency`. """
+        # There are 12 occurances with a monthly frequency:
+        timing = Timing(frequency="M")
+        self.assertEqual(len(timing), 12)
 
     def test_init_str_when(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a single str parameter, `when`. """
+        # 'start' should convert to 0:
+        timing = Timing(when='start')
+        self.assertEqual(set(timing.keys()), {0})
 
     def test_init_dict_pos(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a dict of all-positive values. """
+        # Technically we use non-negative values:
+        timing_dict = {0: 0, 0.5: 1, 1: 1}
+        # Should convert directly to `Timing` (the 0 value is optional):
+        timing = Timing(timing_dict)
+        total_weight = sum(timing.values())
+        for key, value in timing_dict.items():
+            if value != 0:
+                # Each non-0 value should be present...
+                self.assertIn(key, timing)
+                # ... and both non-0 values should be equally weighted.
+                self.assertEqual(timing[key], total_weight / 2)
+            elif key in timing:
+                # The zero value, if it exists, should remain 0:
+                self.assertEqual(timing[key], 0)
 
     def test_init_dict_neg(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a dict of all-negative values. """
+        # This returns the same result as `test_init_dict_pos`;
+        # the inputs have their sign flipped, but output is the same.
 
-    def test_init_dict_mixed(self):
-        """ TODO """
-        pass
+        # Technically we use non-positive values:
+        timing_dict = {0: 0, 0.5: -1, 1: -1}
+        # Should convert directly to `Timing`, except that all values
+        # have their sign flipped (the 0 value is optional):
+        timing = Timing(timing_dict)
+        # Ensure that `total_weight` is positive; the later assertEqual
+        # tests will thus also check that all values are non-negative:
+        total_weight = abs(sum(timing.values()))
+        for key, value in timing_dict.items():
+            if value != 0:
+                # Each non-0 value should be present...
+                self.assertIn(key, timing)
+                # ... and both non-0 values should be equally weighted.
+                self.assertEqual(timing[key], total_weight / 2)
+            elif key in timing:
+                # The zero value, if it exists, should remain 0:
+                self.assertEqual(timing[key], 0)
+
+    def test_init_dict_mixed_pos(self):
+        """ Init `Timing` with a net-positive dict of mixed values.
+
+        "Mixed" in this context means it has both positive and negative
+        values. The sum of those values is positive in this test.
+        """
+        # Large inflow followed by small outflow (for small net inflow):
+        timing_dict = {0: 0, 0.5: 2, 1: -1}
+        timing = Timing(timing_dict)
+        # There should be only one key with non-zero weight:
+        self.assertNotEqual(timing[0.5], 0)
+        # All other keys must have zero weight, if they exist:
+        self.assertTrue(
+            all(value == 0 for key, value in timing.items() if key != 0.5))
+
+    def test_init_dict_mixed_neg(self):
+        """ Init `Timing` with a net-negative dict of mixed values.
+
+        "Mixed" in this context means it has both positive and negative
+        values. The sum of those values is negative in this test.
+        """
+        # Large outflow followed by small inflow and then another large
+        # outflow:
+        timing_dict = {0: 0, 0.5: -2, 0.75: 1, 1: -2}
+        timing = Timing(timing_dict)
+        # This should result in a time-series of {0.5: 2, 1: 1} to
+        # balance the net flows at each outflow.
+        # NOTE: The behaviour is different than is provided for inflows!
+        self.assertNotEqual(timing[0.5], 0)
+        self.assertNotEqual(timing[1], 0)
+        # Key 0.5 should have 2x the weight of key 1:
+        self.assertEqual(timing[0.5], timing[1] * 2)
+        # All other keys must have zero weight, if they exist:
+        self.assertTrue(
+            all(
+                value == 0 for key, value in timing.items()
+                if key not in (0.5, 1)))
+
+    def test_init_dict_mixed_zero(self):
+        """ Init `Timing` with a net-zero dict of mixed values.
+
+        "Mixed" in this context means it has both positive and negative
+        values. The sum of those values is zero in this test.
+        """
+        # Large outflow followed by equally large inflow:
+        timing_dict = {0: 0, 0.5: -2, 1: 2}
+        timing = Timing(timing_dict)
+        # This should result in either an empty time-series or one with
+        # all-zero values.
+        self.assertTrue(all(value == 0 for value in timing.values()))
 
     def test_init_dict_money(self):
-        """ TODO """
-        pass
+        """ Init `Timing` with a dict of `Money` values. """
+        # It doesn't matter what this dict is; if we wrap its values as
+        # `Money` objects, it should parse to the same result:
+        timing_dict = {0: 0, 0.5: -2, 1: 1}
+        money_dict = {key: Money(value) for key, value in timing_dict.items()}
+        # Build timings based on the (otherwise-identical) Money and
+        # non-Money inputs and confirm that the results are the same:
+        timing1 = Timing(timing_dict)
+        timing2 = Timing(money_dict)
+        self.assertEqual(timing1, timing2)
 
-    def test_init_dict_accum(self):
-        """ TODO """
+    def test_init_dict_mixed_neg_2(self):
+        """ Init `Timing` with a net-negative dict of mixed values.
+
+        This tests basically the same behaviour as
+        `test_init_dict_mixed_neg`, but was written much earlier
+        (as `test_init_dict_accum`) and helped to track down some
+        erroneous behaviour. It's retained for historical reasons.
+        """
         available = {0: 1000, 0.25: -11000, 0.5: 1000, 0.75: -11000}
         timing = Timing(available)
         target = Timing({0.25: 10000, 0.75: 10000})
         self.assertEqual(timing, target)
 
-    def test_time_series(self):
+    def test_time_series_basic(self):
+        """ Tests `time_series` for a simple `Timing` object. """
+        # start and end are equally weighted:
+        timing = Timing({0: 1, 1: 1})
+        result = timing.time_series(2)
+        # Spreading a value of 2 equally across start and end means
+        # allocating 1 at start and 1 at end:
+        self.assertEqual(result, {0: 1, 1: 1})
+
+    def test_time_series_subset(self):
+        """ TODO """
+        pass
+
+    def test_normalized_basic(self):
+        """ TODO """
+        pass
+
+    def test_normalized_subset(self):
         """ TODO """
         pass
 

--- a/tests/test_utility.py
+++ b/tests/test_utility.py
@@ -158,7 +158,7 @@ class TestTiming(unittest.TestCase):
         self.assertEqual(timing, target)
 
     def test_time_series_basic(self):
-        """ Tests `time_series` for a simple `Timing` object. """
+        """ Tests `time_series` with simple input. """
         # start and end are equally weighted:
         timing = Timing({0: 1, 1: 1})
         result = timing.time_series(2)
@@ -167,16 +167,32 @@ class TestTiming(unittest.TestCase):
         self.assertEqual(result, {0: 1, 1: 1})
 
     def test_time_series_subset(self):
-        """ TODO """
-        pass
+        """ Tests `time_series` for a subset of keys. """
+        # start and end are equally weighted:
+        timing = Timing({0: 1, 1: 1})
+        result = timing.time_series(2, keys={1})
+        # Spreading a value of 2 equally across _just end_ means
+        # allocating 2 at end:
+        self.assertEqual(result, {1: 2})
 
     def test_normalized_basic(self):
-        """ TODO """
-        pass
+        """ Tests `normalized` with simple input. """
+        # start and end are equally weighted:
+        timing = Timing({0: 1, 1: 1})
+        result = timing.normalized()
+        # start and end are equally weighted, so each should get 0.5
+        # when normalized:
+        target = Timing({0: 0.5, 1: 0.5})
+        self.assertEqual(result, target)
 
     def test_normalized_subset(self):
-        """ TODO """
-        pass
+        """ Tests `normalized` for a subset of keys. """
+        # start and end are equally weighted:
+        timing = Timing({0: 1, 1: 1})
+        result = timing.normalized(keys={1})
+        # Normalizing just end should yield a value of 1 at that time:
+        target = Timing({1: 1})
+        self.assertEqual(result, target)
 
 class TestFreeMethods(unittest.TestCase):
     """ A test case for the free methods in the utility module. """


### PR DESCRIPTION
Adding a `TaxMulti` class to serve as the superclass for multi-jurisdiction `Tax`-like objects. Reimplementing `TaxCanada` as a subsclass of `TaxMulti`. Closes #50.

(Note that this PR includes some commits relating to `Timing` - namely `47de538`-`64709c3`. These have already been merged into the `master` branch via PR #73. Rather than fiddle with this branch via `git rebase` or `git cherry-pick`, I've left them in, which should be harmless.)